### PR TITLE
fix: remove patten logic

### DIFF
--- a/bl/evaluator.go
+++ b/bl/evaluator.go
@@ -20,7 +20,7 @@ type CLIClient interface {
 	RequestEvaluation(cliClient.EvaluationRequest) (cliClient.EvaluationResponse, error)
 }
 type PropertiesExtractor interface {
-	ReadFilesFromPattern(pattern string, conc int) ([]*propertiesExtractor.FileProperties, []propertiesExtractor.FileError, []error)
+	ReadFilesFromPaths(paths []string, conc int) ([]*propertiesExtractor.FileProperties, []propertiesExtractor.FileError, []error)
 }
 
 type Evaluator struct {
@@ -54,8 +54,8 @@ type UserAgent struct {
 	KernelVersion   string
 }
 
-func (e *Evaluator) Evaluate(pattern string, cliId string, evaluationConc int, cliVersion string) (*EvaluationResults, []propertiesExtractor.FileError, error) {
-	files, fileErrors, errors := e.propertiesExtractor.ReadFilesFromPattern(pattern, evaluationConc)
+func (e *Evaluator) Evaluate(paths []string, cliId string, evaluationConc int, cliVersion string) (*EvaluationResults, []propertiesExtractor.FileError, error) {
+	files, fileErrors, errors := e.propertiesExtractor.ReadFilesFromPaths(paths, evaluationConc)
 	if len(errors) > 0 {
 		return nil, fileErrors, fmt.Errorf("failed evaluation with the following errors: %s", errors)
 	}
@@ -71,8 +71,7 @@ func (e *Evaluator) Evaluate(pattern string, cliId string, evaluationConc int, c
 	}
 
 	evaluationRequest := cliClient.EvaluationRequest{
-		CliId:   cliId,
-		Pattern: pattern,
+		CliId: cliId,
 		Metadata: cliClient.Metadata{
 			CliVersion:      cliVersion,
 			Os:              e.osInfo.OS,

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -18,7 +18,7 @@ type LocalConfigManager interface {
 type Evaluator interface {
 	PrintResults(results *bl.EvaluationResults, cliId string, output string) error
 	PrintFileParsingErrors(errors []propertiesExtractor.FileError)
-	Evaluate(patterns []string, cliId string, evaluationConc int, cliVersion string) (*bl.EvaluationResults, []propertiesExtractor.FileError, error)
+	Evaluate(paths []string, cliId string, evaluationConc int, cliVersion string) (*bl.EvaluationResults, []propertiesExtractor.FileError, error)
 }
 
 type TestCommandContext struct {

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"fmt"
-	"path/filepath"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -19,7 +18,7 @@ type LocalConfigManager interface {
 type Evaluator interface {
 	PrintResults(results *bl.EvaluationResults, cliId string, output string) error
 	PrintFileParsingErrors(errors []propertiesExtractor.FileError)
-	Evaluate(pattern string, cliId string, evaluationConc int, cliVersion string) (*bl.EvaluationResults, []propertiesExtractor.FileError, error)
+	Evaluate(patterns []string, cliId string, evaluationConc int, cliVersion string) (*bl.EvaluationResults, []propertiesExtractor.FileError, error)
 }
 
 type TestCommandContext struct {
@@ -45,9 +44,8 @@ func NewTestCommand(ctx *TestCommandContext) *cobra.Command {
 			}
 
 			testCommandFlags := TestCommandFlags{Output: outputFlag}
-			return test(ctx, args[0], testCommandFlags)
+			return test(ctx, args, testCommandFlags)
 		},
-		Args:          cobra.ExactValidArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -56,13 +54,7 @@ func NewTestCommand(ctx *TestCommandContext) *cobra.Command {
 	return testCommand
 }
 
-func test(ctx *TestCommandContext, pattern string, flags TestCommandFlags) error {
-	absolutePath, err := filepath.Abs(pattern)
-	if err != nil {
-		fmt.Println(err)
-		return err
-	}
-
+func test(ctx *TestCommandContext, paths []string, flags TestCommandFlags) error {
 	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 
 	s.Suffix = " Loading..."
@@ -75,7 +67,7 @@ func test(ctx *TestCommandContext, pattern string, flags TestCommandFlags) error
 		return err
 	}
 
-	evaluationResponse, fileParsingErrors, err := ctx.Evaluator.Evaluate(absolutePath, config.CliId, 50, ctx.CliVersion)
+	evaluationResponse, fileParsingErrors, err := ctx.Evaluator.Evaluate(paths, config.CliId, 50, ctx.CliVersion)
 	s.Stop()
 
 	if err != nil {

--- a/cmd/test/main_test.go
+++ b/cmd/test/main_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/datreeio/datree/bl"
@@ -32,8 +31,8 @@ func (m *mockEvaluator) PrintFileParsingErrors(errors []propertiesExtractor.File
 	m.Called(errors)
 }
 
-func (m *mockEvaluator) Evaluate(pattern string, cliId string, evaluationConc int, cliVersion string) (*bl.EvaluationResults, []propertiesExtractor.FileError, error) {
-	args := m.Called(pattern, cliId, evaluationConc)
+func (m *mockEvaluator) Evaluate(paths []string, cliId string, evaluationConc int, cliVersion string) (*bl.EvaluationResults, []propertiesExtractor.FileError, error) {
+	args := m.Called(paths, cliId, evaluationConc)
 	return args.Get(0).(*bl.EvaluationResults), args.Get(1).([]propertiesExtractor.FileError), args.Error(2)
 }
 func TestTestCommand(t *testing.T) {
@@ -63,31 +62,28 @@ func TestTestCommand(t *testing.T) {
 }
 
 func test_testCommand_no_flags(t *testing.T, localConfigManager *mockLocalConfigManager, evaluator *mockEvaluator, mockedEvaluateResponse *bl.EvaluationResults, ctx *TestCommandContext) {
-	test(ctx, "8/*", TestCommandFlags{})
+	test(ctx, []string{"8/*"}, TestCommandFlags{})
 	localConfigManager.AssertCalled(t, "GetConfiguration")
 
-	expectedPath, _ := filepath.Abs("8/*")
-	evaluator.AssertCalled(t, "Evaluate", expectedPath, "134kh", 50)
+	evaluator.AssertCalled(t, "Evaluate", []string{"8/*"}, "134kh", 50)
 	evaluator.AssertNotCalled(t, "PrintFileParsingErrors")
 	evaluator.AssertCalled(t, "PrintResults", mockedEvaluateResponse, "134kh", "")
 }
 
 func test_testCommand_json_output(t *testing.T, localConfigManager *mockLocalConfigManager, evaluator *mockEvaluator, mockedEvaluateResponse *bl.EvaluationResults, ctx *TestCommandContext) {
-	test(ctx, "8/*", TestCommandFlags{Output: "json"})
+	test(ctx, []string{"8/*"}, TestCommandFlags{Output: "json"})
 	localConfigManager.AssertCalled(t, "GetConfiguration")
 
-	expectedPath, _ := filepath.Abs("8/*")
-	evaluator.AssertCalled(t, "Evaluate", expectedPath, "134kh", 50)
+	evaluator.AssertCalled(t, "Evaluate", []string{"8/*"}, "134kh", 50)
 	evaluator.AssertNotCalled(t, "PrintFileParsingErrors")
 	evaluator.AssertCalled(t, "PrintResults", mockedEvaluateResponse, "134kh", "json")
 }
 
 func test_testCommand_yaml_output(t *testing.T, localConfigManager *mockLocalConfigManager, evaluator *mockEvaluator, mockedEvaluateResponse *bl.EvaluationResults, ctx *TestCommandContext) {
-	test(ctx, "8/*", TestCommandFlags{Output: "yaml"})
+	test(ctx, []string{"8/*"}, TestCommandFlags{Output: "yaml"})
 	localConfigManager.AssertCalled(t, "GetConfiguration")
 
-	expectedPath, _ := filepath.Abs("8/*")
-	evaluator.AssertCalled(t, "Evaluate", expectedPath, "134kh", 50)
+	evaluator.AssertCalled(t, "Evaluate", []string{"8/*"}, "134kh", 50)
 	evaluator.AssertNotCalled(t, "PrintFileParsingErrors")
 	evaluator.AssertCalled(t, "PrintResults", mockedEvaluateResponse, "134kh", "yaml")
 }

--- a/pkg/cliClient/cliClient.go
+++ b/pkg/cliClient/cliClient.go
@@ -33,7 +33,6 @@ type Metadata struct {
 
 type EvaluationRequest struct {
 	CliId    string                     `json:"cliId"`
-	Pattern  string                     `json:"pattern"`
 	Metadata Metadata                   `json:"metadata"`
 	Files    []extractor.FileProperties `json:"files"`
 }

--- a/pkg/cliClient/cliClient_test.go
+++ b/pkg/cliClient/cliClient_test.go
@@ -118,9 +118,8 @@ func test_requestEvaluation_success() *RequestEvaluationTestCase {
 			evaluationRequest *EvaluationRequest
 		}{
 			evaluationRequest: &EvaluationRequest{
-				CliId:   "cli-id-test",
-				Pattern: "pattern",
-				Files:   castPropertiesMock("service_mock", "mocks/service_mock.yaml"),
+				CliId: "cli-id-test",
+				Files: castPropertiesMock("service_mock", "mocks/service_mock.yaml"),
 				Metadata: Metadata{
 					CliVersion:      "0.0.1",
 					Os:              "darwin",
@@ -161,9 +160,8 @@ func test_requestEvaluation_success() *RequestEvaluationTestCase {
 				method: http.MethodPost,
 				uri:    "/cli/evaluate",
 				body: &EvaluationRequest{
-					CliId:   "cli-id-test",
-					Pattern: "pattern",
-					Files:   castPropertiesMock("service_mock", "mocks/service_mock.yaml"),
+					CliId: "cli-id-test",
+					Files: castPropertiesMock("service_mock", "mocks/service_mock.yaml"),
 					Metadata: Metadata{
 						CliVersion:      "0.0.1",
 						Os:              "darwin",

--- a/pkg/fileReader/reader.go
+++ b/pkg/fileReader/reader.go
@@ -65,12 +65,12 @@ func (fr *FileReader) ReadFileContent(filepath string) (string, error) {
 	return string(dat), nil
 }
 
-func (fr *FileReader) GetFilesPaths(pattern string) (chan string, chan error) {
+func (fr *FileReader) GetFilesPaths(paths []string) (chan string, chan error) {
 	errorChan := make(chan error, 100)
 	filePathsChan := make(chan string, 100)
 
 	go func() {
-		matches, err := fr.glob(pattern)
+		var err error
 
 	iterateMatches:
 		for {
@@ -79,7 +79,7 @@ func (fr *FileReader) GetFilesPaths(pattern string) (chan string, chan error) {
 				break iterateMatches
 			}
 
-			for _, match := range matches {
+			for _, match := range paths {
 				file, err := fr.stat(match)
 				if err != nil {
 					errorChan <- err

--- a/pkg/fileReader/reader_test.go
+++ b/pkg/fileReader/reader_test.go
@@ -142,13 +142,9 @@ func TestCreateFileReader(t *testing.T) {
 type getFilesPathsTestCase struct {
 	name string
 	args struct {
-		pattern string
+		paths []string
 	}
 	mock struct {
-		glob struct {
-			response []string
-			err      error
-		}
 		stat struct {
 			response os.FileInfo
 			err      error
@@ -159,10 +155,6 @@ type getFilesPathsTestCase struct {
 		}
 	}
 	expected struct {
-		glob struct {
-			calledWith string
-			isCalled   bool
-		}
 		stat struct {
 			calledWith string
 			isCalled   bool
@@ -188,7 +180,6 @@ func TestGetFilesPaths(t *testing.T) {
 			stat := statMock{}
 			abs := absMock{}
 
-			glob.On("Glob", mock.Anything).Return(tt.mock.glob.response, tt.mock.glob.err)
 			abs.On("Abs", mock.Anything).Return(tt.mock.abs.response, tt.mock.abs.err)
 			stat.On("Stat", mock.Anything).Return(tt.mock.stat.response, tt.mock.stat.err)
 
@@ -199,7 +190,7 @@ func TestGetFilesPaths(t *testing.T) {
 				abs:      abs.Abs,
 			}
 
-			res, err := fileReader.GetFilesPaths(tt.args.pattern)
+			res, err := fileReader.GetFilesPaths(tt.args.paths)
 
 			var actualRes []string
 			for m := range res {
@@ -213,10 +204,6 @@ func TestGetFilesPaths(t *testing.T) {
 
 			assert.Equal(t, tt.expected.response, actualRes)
 			assert.Equal(t, tt.expected.err, actualErrs)
-
-			if tt.expected.glob.isCalled {
-				glob.AssertCalled(t, "Glob", tt.expected.glob.calledWith)
-			}
 
 			if tt.expected.abs.isCalled {
 				abs.AssertCalled(t, "Abs", tt.expected.abs.calledWith)
@@ -233,14 +220,10 @@ func TestGetFilesPaths(t *testing.T) {
 func getFilesPaths_noMatchesTestCase() getFilesPathsTestCase {
 	return getFilesPathsTestCase{
 		name: "success no matches",
-		args: struct{ pattern string }{
-			pattern: "*",
+		args: struct{ paths []string }{
+			paths: []string{},
 		},
 		mock: struct {
-			glob struct {
-				response []string
-				err      error
-			}
 			stat struct {
 				response os.FileInfo
 				err      error
@@ -250,13 +233,6 @@ func getFilesPaths_noMatchesTestCase() getFilesPathsTestCase {
 				err      error
 			}
 		}{
-			glob: struct {
-				response []string
-				err      error
-			}{
-				response: make([]string, 0),
-				err:      nil,
-			},
 			stat: struct {
 				response os.FileInfo
 				err      error
@@ -273,10 +249,6 @@ func getFilesPaths_noMatchesTestCase() getFilesPathsTestCase {
 			},
 		},
 		expected: struct {
-			glob struct {
-				calledWith string
-				isCalled   bool
-			}
 			stat struct {
 				calledWith string
 				isCalled   bool
@@ -288,13 +260,6 @@ func getFilesPaths_noMatchesTestCase() getFilesPathsTestCase {
 			response []string
 			err      []error
 		}{
-			glob: struct {
-				calledWith string
-				isCalled   bool
-			}{
-				calledWith: "*",
-				isCalled:   true,
-			},
 			stat: struct {
 				calledWith string
 				isCalled   bool
@@ -338,14 +303,10 @@ func getFilesPaths_withMatchesTestCase() getFilesPathsTestCase {
 
 	return getFilesPathsTestCase{
 		name: "success with matches",
-		args: struct{ pattern string }{
-			pattern: "./mock/*",
+		args: struct{ paths []string }{
+			paths: []string{"./fail-30.yaml"},
 		},
 		mock: struct {
-			glob struct {
-				response []string
-				err      error
-			}
 			stat struct {
 				response os.FileInfo
 				err      error
@@ -355,13 +316,6 @@ func getFilesPaths_withMatchesTestCase() getFilesPathsTestCase {
 				err      error
 			}
 		}{
-			glob: struct {
-				response []string
-				err      error
-			}{
-				response: []string{"./fail-30.yaml"},
-				err:      nil,
-			},
 			stat: struct {
 				response os.FileInfo
 				err      error
@@ -378,10 +332,6 @@ func getFilesPaths_withMatchesTestCase() getFilesPathsTestCase {
 			},
 		},
 		expected: struct {
-			glob struct {
-				calledWith string
-				isCalled   bool
-			}
 			stat struct {
 				calledWith string
 				isCalled   bool
@@ -393,13 +343,6 @@ func getFilesPaths_withMatchesTestCase() getFilesPathsTestCase {
 			response []string
 			err      []error
 		}{
-			glob: struct {
-				calledWith string
-				isCalled   bool
-			}{
-				calledWith: "./mock/*",
-				isCalled:   true,
-			},
 			stat: struct {
 				calledWith string
 				isCalled   bool

--- a/pkg/propertiesExtractor/propertiesExtractor.go
+++ b/pkg/propertiesExtractor/propertiesExtractor.go
@@ -12,7 +12,7 @@ import (
 
 type FileReader interface {
 	ReadFileContent(filepath string) (string, error)
-	GetFilesPaths(pattern string) (chan string, chan error)
+	GetFilesPaths(paths []string) (chan string, chan error)
 }
 
 type PropertiesExtractor struct {
@@ -42,8 +42,8 @@ func NewPropertiesExtractor(fr FileReader) *PropertiesExtractor {
 	}
 }
 
-func (e *PropertiesExtractor) ReadFilesFromPattern(pattern string, conc int) ([]*FileProperties, []FileError, []error) {
-	filePathsChan, getFilesPathsErrorsChan := e.reader.GetFilesPaths(pattern)
+func (e *PropertiesExtractor) ReadFilesFromPaths(paths []string, conc int) ([]*FileProperties, []FileError, []error) {
+	filePathsChan, getFilesPathsErrorsChan := e.reader.GetFilesPaths(paths)
 	filesPropertiesChan, extractPropertiesErrorsChan := e.extractFilesProperties(filePathsChan, conc)
 
 	var files []*FileProperties

--- a/pkg/propertiesExtractor/propertiesExtractor_test.go
+++ b/pkg/propertiesExtractor/propertiesExtractor_test.go
@@ -19,8 +19,8 @@ func (m *mockFileReader) ReadFileContent(filepath string) (string, error) {
 	return args.Get(0).(string), args.Error(1)
 }
 
-func (m *mockFileReader) GetFilesPaths(pattern string) (chan string, chan error) {
-	args := m.Called(pattern)
+func (m *mockFileReader) GetFilesPaths(paths []string) (chan string, chan error) {
+	args := m.Called(paths)
 	return args.Get(0).(chan string), args.Get(1).(chan error)
 }
 
@@ -55,8 +55,8 @@ func TestNewPropertiesExtractor(t *testing.T) {
 type readFilesFromPatternTestCase struct {
 	name string
 	args struct {
-		conc    int
-		pattern string
+		conc  int
+		paths []string
 	}
 	mock struct {
 		readFileContentResponse struct {
@@ -92,9 +92,9 @@ func TestReadFilesFromPattern(t *testing.T) {
 			propertiesExtractor := &PropertiesExtractor{
 				reader: fileReader,
 			}
-			actualFilesProperties, actualFileErrs, actualErrors := propertiesExtractor.ReadFilesFromPattern(tt.args.pattern, tt.args.conc)
+			actualFilesProperties, actualFileErrs, actualErrors := propertiesExtractor.ReadFilesFromPaths(tt.args.paths, tt.args.conc)
 
-			fileReader.AssertCalled(t, "GetFilesPaths", tt.args.pattern)
+			fileReader.AssertCalled(t, "GetFilesPaths", tt.args.paths)
 			fileReader.AssertCalled(t, "ReadFileContent", tt.expected.readFileContentCalledWith[0])
 
 			for i, prop := range actualFilesProperties {
@@ -116,11 +116,11 @@ func test_readFileFromPattern_success() readFilesFromPatternTestCase {
 	return readFilesFromPatternTestCase{
 		name: "success",
 		args: struct {
-			conc    int
-			pattern string
+			conc  int
+			paths []string
 		}{
-			conc:    5,
-			pattern: "pattern/*",
+			conc:  5,
+			paths: []string{"path1/path2/file.yaml"},
 		},
 		mock: struct {
 			readFileContentResponse struct {
@@ -165,11 +165,11 @@ func test_readFileFromPattern_invalidYaml() readFilesFromPatternTestCase {
 	return readFilesFromPatternTestCase{
 		name: "invalid yaml",
 		args: struct {
-			conc    int
-			pattern string
+			conc  int
+			paths []string
 		}{
-			conc:    5,
-			pattern: "pattern/*",
+			conc:  5,
+			paths: []string{"path1/path2/file.yaml"},
 		},
 		mock: struct {
 			readFileContentResponse struct {
@@ -214,11 +214,11 @@ func test_readFileFromPattern_invalidFile() readFilesFromPatternTestCase {
 	return readFilesFromPatternTestCase{
 		name: "invalid yaml",
 		args: struct {
-			conc    int
-			pattern string
+			conc  int
+			paths []string
 		}{
-			conc:    5,
-			pattern: "pattern/*",
+			conc:  5,
+			paths: []string{"path1/path2/file.yaml"},
 		},
 		mock: struct {
 			readFileContentResponse struct {


### PR DESCRIPTION
* Removed dependencies in external glob packages
* Path now supports simple `datree test <path>` without the need for parentheses
* Removed `pattern` from the request content to the cli service 