### PR TITLE
feat: k8s version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ run:
 test:
 	go test ./...
 
+build:
+	go build -tags staging -ldflags="-X github.com/datreeio/datree/cmd.CliVersion=0.0.1" main.go
+
 create-bin:
 	goreleaser --snapshot --skip-publish --rm-dist
 

--- a/bl/evaluation/evaluator.go
+++ b/bl/evaluation/evaluator.go
@@ -40,9 +40,10 @@ type Error struct {
 	Filename string
 }
 
-func (e *Evaluator) CreateEvaluation(cliId string, cliVersion string) (int, error) {
+func (e *Evaluator) CreateEvaluation(cliId string, cliVersion string, k8sVersion string) (int, error) {
 	evaluationId, err := e.cliClient.CreateEvaluation(&cliClient.CreateEvaluationRequest{
-		CliId: cliId,
+		K8sVersion: k8sVersion,
+		CliId:      cliId,
 		Metadata: &cliClient.Metadata{
 			CliVersion:      cliVersion,
 			Os:              e.osInfo.OS,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/datreeio/datree/bl/evaluation"
 	"github.com/datreeio/datree/bl/messager"
-	"github.com/datreeio/datree/bl/validation"
 	"github.com/datreeio/datree/cmd/test"
 	"github.com/datreeio/datree/cmd/version"
 	"github.com/datreeio/datree/pkg/cliClient"
@@ -25,12 +24,11 @@ func init() {
 	app := startup()
 
 	rootCmd.AddCommand(test.New(&test.TestCommandContext{
-		CliVersion:   CliVersion,
-		Evaluator:    app.context.Evaluator,
-		LocalConfig:  app.context.LocalConfig,
-		Messager:     app.context.Messager,
-		K8sValidator: app.context.Validator,
-		Printer:      app.context.Printer,
+		CliVersion:  CliVersion,
+		Evaluator:   app.context.Evaluator,
+		LocalConfig: app.context.LocalConfig,
+		Messager:    app.context.Messager,
+		Printer:     app.context.Printer,
 	}))
 
 	rootCmd.AddCommand(version.New(&version.VersionCommandContext{
@@ -49,7 +47,6 @@ type context struct {
 	Evaluator   *evaluation.Evaluator
 	CliClient   *cliClient.CliClient
 	Messager    *messager.Messager
-	Validator   *validation.K8sValidator
 	Printer     *printer.Printer
 }
 type app struct {
@@ -67,7 +64,6 @@ func startup() *app {
 			Evaluator:   evaluation.New(cliClient),
 			CliClient:   cliClient,
 			Messager:    messager.New(cliClient),
-			Validator:   validation.New("1.18.0"),
 			Printer:     printer,
 		},
 	}

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -2,8 +2,9 @@ package test
 
 import (
 	"fmt"
-	"github.com/datreeio/datree/pkg/cliClient"
 	"time"
+
+	"github.com/datreeio/datree/pkg/cliClient"
 
 	"github.com/briandowns/spinner"
 	"github.com/datreeio/datree/bl/evaluation"
@@ -16,7 +17,7 @@ import (
 
 type Evaluator interface {
 	Evaluate(validFilesPathsChan chan string, invalidFilesPaths chan *validation.InvalidFile, evaluationId int) (*evaluation.EvaluationResults, []*validation.InvalidFile, []*cliClient.FileConfiguration, []*evaluation.Error, error)
-	CreateEvaluation(cliId string, cliVersion string) (int, error)
+	CreateEvaluation(cliId string, cliVersion string, k8sVersion string) (int, error)
 }
 
 type Messager interface {
@@ -28,7 +29,8 @@ type K8sValidator interface {
 }
 
 type TestCommandFlags struct {
-	Output string
+	Output     string
+	K8sVersion string
 }
 
 type EvaluationPrinter interface {
@@ -58,7 +60,14 @@ func New(ctx *TestCommandContext) *cobra.Command {
 				return err
 			}
 
-			testCommandFlags := TestCommandFlags{Output: outputFlag}
+			k8sVersion, err := cmd.Flags().GetString("k8s-version")
+			if err != nil {
+				fmt.Println(err)
+				return err
+			}
+
+			testCommandFlags := TestCommandFlags{Output: outputFlag, K8sVersion: k8sVersion}
+			ctx.K8sValidator = validation.New(k8sVersion)
 			return test(ctx, args, testCommandFlags)
 		},
 		SilenceUsage:  true,
@@ -66,6 +75,7 @@ func New(ctx *TestCommandContext) *cobra.Command {
 	}
 
 	testCommand.Flags().StringP("output", "o", "", "Define output format")
+	testCommand.Flags().StringP("k8s-version", "k", "1.18.0", "Set kubernetes version to validate against. Defaults to 1.18.0")
 	return testCommand
 }
 
@@ -76,19 +86,18 @@ func test(ctx *TestCommandContext, paths []string, flags TestCommandFlags) error
 	messages := make(chan *messager.VersionMessage, 1)
 	go ctx.Messager.LoadVersionMessages(messages, ctx.CliVersion)
 
-	validFilesPaths, invalidFilesPathsChan, errorsChan := ctx.K8sValidator.ValidateResources(paths)
+	evaluationId, err := ctx.Evaluator.CreateEvaluation(ctx.LocalConfig.CliId, ctx.CliVersion, flags.K8sVersion)
+	if err != nil {
+		fmt.Println(err.Error())
+		return err
+	}
 
+	validFilesPaths, invalidFilesPathsChan, errorsChan := ctx.K8sValidator.ValidateResources(paths)
 	go func() {
 		for err := range errorsChan {
 			fmt.Println(err)
 		}
 	}()
-
-	evaluationId, err := ctx.Evaluator.CreateEvaluation(ctx.LocalConfig.CliId, ctx.CliVersion)
-	if err != nil {
-		fmt.Println(err.Error())
-		return err
-	}
 
 	results, invalidFiles, filesConfigurations, errors, err := ctx.Evaluator.Evaluate(validFilesPaths, invalidFilesPathsChan, evaluationId)
 

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -75,7 +75,7 @@ func New(ctx *TestCommandContext) *cobra.Command {
 	}
 
 	testCommand.Flags().StringP("output", "o", "", "Define output format")
-	testCommand.Flags().StringP("k8s-version", "k", "1.18.0", "Set kubernetes version to validate against. Defaults to 1.18.0")
+	testCommand.Flags().StringP("schema-version", "s", "1.18.0", "Set kubernetes version to validate against. Defaults to 1.18.0")
 	return testCommand
 }
 

--- a/pkg/cliClient/evaluation.go
+++ b/pkg/cliClient/evaluation.go
@@ -13,8 +13,9 @@ type Metadata struct {
 }
 
 type CreateEvaluationRequest struct {
-	CliId    string    `json:"cliId"`
-	Metadata *Metadata `json:"metadata"`
+	CliId      string    `json:"cliId"`
+	Metadata   *Metadata `json:"metadata"`
+	K8sVersion string    `json:"k8sVersion"`
 }
 
 func (c *CliClient) CreateEvaluation(request *CreateEvaluationRequest) (int, error) {


### PR DESCRIPTION
* Added k8s version flag to the cli [--schema-version | -s] -> default to 1.18.0
* Use the kubeconform validator with the flag input from the user
* Send data to cli service and make sure k8s version is updated correctly for history