### PR TITLE
fix: reset console colors back to default

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,4 +40,6 @@ echo -e "\033[35m Usage: $ datree test ~/.datree/k8s-demo.yaml"
 
 echo -e " Using Helm? => https://hub.datree.io/helm-plugin"
 
+tput init
+
 echo


### PR DESCRIPTION
At the moment when you install detree it will end up with [`\033[35m`](https://github.com/datreeio/datree/blob/staging/install.sh#L39) this color. This fix should work on both Linux and macOS and put the console colors back to default.