### PR TITLE
Add XML output support

### DIFF
--- a/bl/evaluation/evaluator.go
+++ b/bl/evaluation/evaluator.go
@@ -25,8 +25,10 @@ func New(c CLIClient) *Evaluator {
 	}
 }
 
+type FileNameRuleMapper map[string]map[int]*Rule 
+
 type EvaluationResults struct {
-	FileNameRuleMapper map[string]map[int]*Rule
+	FileNameRuleMapper FileNameRuleMapper
 	Summary            struct {
 		TotalFailedRules int
 		FilesCount       int

--- a/bl/evaluation/printer.go
+++ b/bl/evaluation/printer.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"strconv"
 
 	"github.com/datreeio/datree/bl/validation"
 
@@ -248,17 +247,15 @@ func (mapper FileNameRuleMapper) MarshalXML(e *xml.Encoder, start xml.StartEleme
 	if len(mapper) == 0 {
 		return nil
 	}
-	
+
 	tokens := []xml.Token{start}
 
 	// Iterate over mapper and create XML tokens for all entries
 	for eKey, eValue := range mapper {
-		for iKey, iValue := range eValue {
+		for _, iValue := range eValue {
 			eStartToken := xml.StartElement{Name: xml.Name{Space: "", Local: eKey}}
-			iStartToken := xml.StartElement{Name: xml.Name{Space: "", Local: strconv.Itoa(iKey)}}
-			iEndToken := xml.EndElement{Name: iStartToken.Name}
 			eEndToken := xml.EndElement{Name: eStartToken.Name}
-			tokens = append(tokens, eStartToken, iStartToken, iValue, iValue, iEndToken, eEndToken)
+			tokens = append(tokens, eStartToken, iValue, iValue, eEndToken)
 		}
 	}
 

--- a/bl/evaluation/printer.go
+++ b/bl/evaluation/printer.go
@@ -249,13 +249,15 @@ func (mapper FileNameRuleMapper) MarshalXML(e *xml.Encoder, start xml.StartEleme
 	}
 
 	tokens := []xml.Token{start}
+	fileXMLName := xml.Name{Space: "", Local: "File"}
+	filenameXMLName := xml.Name{Space: "", Local: "filename"}
 
 	// Iterate over mapper and create XML tokens for all entries
-	for eKey, eValue := range mapper {
-		for _, iValue := range eValue {
-			eStartToken := xml.StartElement{Name: xml.Name{Space: "", Local: eKey}}
-			eEndToken := xml.EndElement{Name: eStartToken.Name}
-			tokens = append(tokens, eStartToken, iValue, eEndToken)
+	for filePath, encapsulatedRule := range mapper {
+		for _, rule := range encapsulatedRule {	// Since rule is encapsulated by its id (int), we don't add is a tag
+			startToken := xml.StartElement{Name: fileXMLName, Attr: []xml.Attr{{Name: filenameXMLName, Value: filePath}}}
+			endToken := xml.EndElement{Name: fileXMLName}
+			tokens = append(tokens, startToken, rule, endToken)
 		}
 	}
 

--- a/bl/evaluation/printer.go
+++ b/bl/evaluation/printer.go
@@ -255,7 +255,7 @@ func (mapper FileNameRuleMapper) MarshalXML(e *xml.Encoder, start xml.StartEleme
 		for _, iValue := range eValue {
 			eStartToken := xml.StartElement{Name: xml.Name{Space: "", Local: eKey}}
 			eEndToken := xml.EndElement{Name: eStartToken.Name}
-			tokens = append(tokens, eStartToken, iValue, iValue, eEndToken)
+			tokens = append(tokens, eStartToken, iValue, eEndToken)
 		}
 	}
 

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -154,7 +154,7 @@ func test(ctx *TestCommandContext, paths []string, flags TestCommandFlags) error
 	if flags.Output == "simple" {
 		ctx.Printer.SetTheme(printer.CreateSimpleTheme())
 	}
-	isInteractiveMode := (flags.Output != "json") && (flags.Output != "yaml")
+	isInteractiveMode := (flags.Output != "json") && (flags.Output != "yaml") && (flags.Output != "xml")
 
 	if isInteractiveMode == true {
 		messages := make(chan *messager.VersionMessage, 1)

--- a/cmd/test/main_test.go
+++ b/cmd/test/main_test.go
@@ -170,6 +170,7 @@ func TestTestCommand(t *testing.T) {
 	test_testCommand_no_flags(t, mockedEvaluator, filesConfigurations, evaluationId, ctx)
 	test_testCommand_json_output(t, mockedEvaluator, filesConfigurations, evaluationId, ctx)
 	test_testCommand_yaml_output(t, mockedEvaluator, filesConfigurations, evaluationId, ctx)
+	test_testCommand_xml_output(t, mockedEvaluator, filesConfigurations, evaluationId, ctx)
 }
 
 func test_testCommand_no_flags(t *testing.T, evaluator *mockEvaluator, filesConfigurations []*extractor.FileConfigurations, evaluationId int, ctx *TestCommandContext) {
@@ -187,6 +188,12 @@ func test_testCommand_json_output(t *testing.T, evaluator *mockEvaluator, filesC
 
 func test_testCommand_yaml_output(t *testing.T, evaluator *mockEvaluator, filesConfigurations []*extractor.FileConfigurations, evaluationId int, ctx *TestCommandContext) {
 	test(ctx, []string{"8/*"}, TestCommandFlags{Output: "yaml"})
+
+	evaluator.AssertCalled(t, "Evaluate", filesConfigurations, evaluationId)
+}
+
+func test_testCommand_xml_output(t *testing.T, evaluator *mockEvaluator, filesConfigurations []*extractor.FileConfigurations, evaluationId int, ctx *TestCommandContext) {
+	test(ctx, []string{"8/*"}, TestCommandFlags{Output: "xml"})
 
 	evaluator.AssertCalled(t, "Evaluate", filesConfigurations, evaluationId)
 }


### PR DESCRIPTION
Relates to #81.
Doesn't completely solve it since Azure DevOps expects the XML to be in JUnit format, but it takes the project one step closer towards that goal.