### PR TITLE
Fix unzip check: /bin/bash: line 18: unzip: command not found

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,8 +16,8 @@ curl -sL $DOWNLOAD_URL -o $OUTPUT_BASENAME_WITH_POSTFIX
 echo -e "\033[32m[V] Downloaded Datree"
 
 if ! unzip >/dev/null 2>&1;then
-    echo -e "\e[1;31m error: unzip command not found \e[0m"
-    echo -e "\e[1;33m install unzip command in your system \e[0m"
+    echo -e "\033[31;1m error: unzip command not found \033[0m"
+    echo -e "\033[33;1m install unzip command in your system \033[0m"
     exit 1
 fi
 
@@ -38,7 +38,7 @@ echo
 
 echo -e "\033[35m Usage: $ datree test ~/.datree/k8s-demo.yaml"
 
-echo -e " Using Helm? => https://hub.datree.io/helm-plugin \e[0m"
+echo -e " Using Helm? => https://hub.datree.io/helm-plugin \033[0m"
 
 tput init
 

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,12 @@ echo
 curl -sL $DOWNLOAD_URL -o $OUTPUT_BASENAME_WITH_POSTFIX
 echo -e "\033[32m[V] Downloaded Datree"
 
+if ! unzip >/dev/null 2>&1;then
+    echo -e "\e[1;31m error: unzip command not found \e[0m"
+    echo -e "\e[1;33m install unzip command in your system \e[0m"
+    exit 1
+fi
+
 unzip -qq $OUTPUT_BASENAME_WITH_POSTFIX -d $OUTPUT_BASENAME
 
 mkdir -p ~/.datree
@@ -32,7 +38,7 @@ echo
 
 echo -e "\033[35m Usage: $ datree test ~/.datree/k8s-demo.yaml"
 
-echo -e " Using Helm? => https://hub.datree.io/helm-plugin"
+echo -e " Using Helm? => https://hub.datree.io/helm-plugin \e[0m"
 
 tput init
 

--- a/internal_install.sh
+++ b/internal_install.sh
@@ -17,6 +17,12 @@ echo
 curl -sL $DOWNLOAD_URL -o $OUTPUT_BASENAME_WITH_POSTFIX
 echo -e "\033[32m[V] Downloaded Datree"
 
+if ! unzip >/dev/null 2>&1;then
+    echo -e "\e[1;31m error: unzip command not found \e[0m"
+    echo -e "\e[1;33m install unzip command in your system \e[0m"
+    exit 1
+fi
+
 unzip -qq $OUTPUT_BASENAME_WITH_POSTFIX -d $OUTPUT_BASENAME
 
 DATREE_CONFIG_PATH=~/.datree
@@ -46,6 +52,6 @@ echo
 
 echo -e "\033[35m Usage: $ datree test ~/.datree/k8s-demo.yaml"
 
-echo -e " Using Helm? => https://hub.datree.io/helm-plugin"
+echo -e " Using Helm? => https://hub.datree.io/helm-plugin \e[0m"
 
 echo

--- a/internal_install.sh
+++ b/internal_install.sh
@@ -18,8 +18,8 @@ curl -sL $DOWNLOAD_URL -o $OUTPUT_BASENAME_WITH_POSTFIX
 echo -e "\033[32m[V] Downloaded Datree"
 
 if ! unzip >/dev/null 2>&1;then
-    echo -e "\e[1;31m error: unzip command not found \e[0m"
-    echo -e "\e[1;33m install unzip command in your system \e[0m"
+    echo -e "\033[31;1m error: unzip command not found \033[0m"
+    echo -e "\033[33;1m install unzip command in your system \033[0m"
     exit 1
 fi
 
@@ -52,6 +52,6 @@ echo
 
 echo -e "\033[35m Usage: $ datree test ~/.datree/k8s-demo.yaml"
 
-echo -e " Using Helm? => https://hub.datree.io/helm-plugin \e[0m"
+echo -e " Using Helm? => https://hub.datree.io/helm-plugin \033[0m"
 
 echo


### PR DESCRIPTION
Facing issue while installing [datree ](https://hub.datree.io/#a-1-install-datrees-cli-integration)
`/bin/bash: line 18: unzip: command not found`
To avoid this error, added an error handling for unzip command in the scripts.

Also, reset font color at the EOD line in the scripts.

Following image shows the error:
![image](https://user-images.githubusercontent.com/16969949/135895776-28ed791d-c9f5-407c-ad68-980eb86f9afc.png)
