### PR TITLE
build: upgrade to Go 1.17

### DIFF
--- a/bl/files/files.go
+++ b/bl/files/files.go
@@ -3,10 +3,10 @@ package files
 import (
 	"bytes"
 	"fmt"
-	"gopkg.in/yaml.v3"
-	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/datreeio/datree/bl/validation"
 	"github.com/datreeio/datree/pkg/extractor"
@@ -71,7 +71,7 @@ func ExtractYamlFileToUnknownStruct(path string) (UnknownStruct, error) {
 		return nil, err
 	}
 
-	yamlContent, err := ioutil.ReadFile(absolutePath)
+	yamlContent, err := os.ReadFile(absolutePath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -3,7 +3,6 @@ package test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -158,7 +157,7 @@ func test(ctx *TestCommandContext, paths []string, flags TestCommandFlags) error
 		if len(paths) > 1 {
 			return fmt.Errorf(fmt.Sprintf("Unexpected args: [%s]", strings.Join(paths[1:], ",")))
 		}
-		tempFile, err := ioutil.TempFile("", "datree_temp_*.yaml")
+		tempFile, err := os.CreateTemp("", "datree_temp_*.yaml")
 		if err != nil {
 			return err
 		}

--- a/cmd/version/main_test.go
+++ b/cmd/version/main_test.go
@@ -2,7 +2,7 @@ package version
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/datreeio/datree/bl/messager"
@@ -45,13 +45,13 @@ func Test_ExecuteCommand(t *testing.T) {
 	cmd := New(&VersionCommandContext{
 		CliVersion: "1.2.3",
 		Messager:   messager,
-		Printer: printer,
+		Printer:    printer,
 	})
 
 	b := bytes.NewBufferString("1.2.3")
 	cmd.SetOut(b)
 	cmd.Execute()
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,12 @@
 module github.com/datreeio/datree
 
-go 1.15
+go 1.17
 
 require (
-	github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 // indirect
 	github.com/bmatcuk/doublestar/v2 v2.0.4
 	github.com/briandowns/spinner v1.12.0
 	github.com/eiannone/keyboard v0.0.0-20200508000154-caf4b762e807
 	github.com/fatih/color v1.10.0
-	github.com/go-ole/go-ole v1.2.5 // indirect
-	github.com/google/uuid v1.2.0 // indirect
 	github.com/kyokomi/emoji v2.2.4+incompatible
 	github.com/lithammer/shortuuid v3.0.0+incompatible
 	github.com/olekukonko/tablewriter v0.0.5
@@ -18,10 +15,39 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
-	github.com/tklauser/go-sysconf v0.3.5 // indirect
 	github.com/yannh/kubeconform v0.4.8
-	golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 // indirect
-	golang.org/x/text v0.3.3 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
+	github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/go-ole/go-ole v1.2.5 // indirect
+	github.com/google/uuid v1.2.0 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/afero v1.1.2 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/jwalterweatherman v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.1.1 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/tklauser/go-sysconf v0.3.5 // indirect
+	github.com/tklauser/numcpus v0.2.2 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	gopkg.in/ini.v1 v1.51.0 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -297,12 +297,8 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa h1:ZYxPR6aca/uhfRJyaOAtflSHjJYiktO7QnJC5ut7iY4=
 golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210319071255-635bc2c9138d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210902050250-f475640dd07b h1:S7hKs0Flbq0bbc9xgYt4stIEG1zNDFqyrPwAX2Wj/sE=
-golang.org/x/sys v0.0.0-20210902050250-f475640dd07b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 h1:J27LZFQBFoihqXoegpscI10HpjZ7B5WQLLKL2FZXQKw=
 golang.org/x/sys v0.0.0-20210917161153-d61c044b1678/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/cliClient/cliClient_test.go
+++ b/pkg/cliClient/cliClient_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -231,7 +231,7 @@ func readMock(path string) ([]extractor.Configuration, error) {
 	var configurations []extractor.Configuration
 
 	absPath, _ := filepath.Abs(path)
-	content, err := ioutil.ReadFile(absPath)
+	content, err := os.ReadFile(absPath)
 
 	if err != nil {
 		return []extractor.Configuration{}, err

--- a/pkg/extractor/extractor.go
+++ b/pkg/extractor/extractor.go
@@ -3,7 +3,7 @@ package extractor
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v3"
 )
@@ -54,7 +54,7 @@ func extractYamlConfigurations(content string) (*[]Configuration, error) {
 }
 
 func ReadFileContent(filepath string) (string, error) {
-	dat, err := ioutil.ReadFile(filepath)
+	dat, err := os.ReadFile(filepath)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/fileReader/reader.go
+++ b/pkg/fileReader/reader.go
@@ -1,7 +1,6 @@
 package fileReader
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -29,7 +28,7 @@ type FileReaderOptions struct {
 
 func CreateFileReader(opts *FileReaderOptions) *FileReader {
 	fileReader := &FileReader{
-		readFile: ioutil.ReadFile,
+		readFile: os.ReadFile,
 		glob:     doublestar.Glob,
 		abs:      filepath.Abs,
 		stat:     os.Stat,

--- a/pkg/httpClient/client.go
+++ b/pkg/httpClient/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -67,7 +66,7 @@ func (c *Client) Request(method string, resourceURI string, body interface{}, he
 
 	defer response.Body.Close()
 
-	b, err := ioutil.ReadAll(response.Body)
+	b, err := io.ReadAll(response.Body)
 	if err != nil {
 		return responseBody, err
 	}

--- a/pkg/httpClient/client_test.go
+++ b/pkg/httpClient/client_test.go
@@ -3,7 +3,7 @@ package httpClient
 import (
 	"bytes"
 	"compress/gzip"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -100,7 +100,7 @@ func createMockServer(t *testing.T, tc *testCase) *httptest.Server {
 
 		assert.Equal(t, tc.path, req.URL.String())
 
-		body, _ := ioutil.ReadAll(req.Body)
+		body, _ := io.ReadAll(req.Body)
 
 		if len(tc.expectedRequestBody) > 0 {
 			gunzippedBody := gunzipBody(body)


### PR DESCRIPTION
1. Since we are already using Go 1.17 in Travis CI, this PR upgrades the `go` directive to 1.17 to enable [module graph pruning](https://golang.org/ref/mod#graph-pruning) and [lazy module loading](https://golang.org/ref/mod#lazy-loading).
2. The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.