### PR TITLE
ci: add docker image build to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,6 @@ jobs:
     env:
       REPO_NAME: datree
       IMAGE_NAME: datree
-      COMMIT_SHA: ${{ github.sha }}
     name: Release container image to public registries
     needs: release
     runs-on: ubuntu-latest
@@ -75,12 +74,6 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Log in to GitHub Container Registry (ghcr.io)
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
     #- uses: docker/setup-qemu-action@v1
     #this should only be needed if building
     #for other platforms like linux/arm64
@@ -93,7 +86,5 @@ jobs:
         tags: |
           ${{ env.REPO_NAME }}/${{ env.IMAGE_NAME }}:latest
           ${{ env.REPO_NAME }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.release_candidate_version }}
-          ghcr.io/${{ REPO_NAME }}/${{ env.IMAGE_NAME }}:latest
-          ghcr.io/${{ REPO_NAME }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.release_candidate_version }}
         cache-from: type=gha
         cache-to: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,18 @@ on:
         required: false
 
 jobs:
+  define_version_job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: define_version
+        name: Define release version
+        run: echo "##[set-output name=version;]$(bash ./scripts/define_release_version.sh ${{ github.event.inputs.release_candidate_version }})"
+    outputs:
+      version: ${{ steps.define_version.outputs.version }}
   release:
     runs-on: ubuntu-latest
+    needs: define_version_job
     steps:
       - name: Extract branch name
         shell: bash
@@ -41,7 +51,7 @@ jobs:
                 \"env\": {
                   \"global\": [
                     \"RELEASE_DATREE_PROD=true\",
-                    \"RELEASE_CANDIDATE_VERSION=${{ github.event.inputs.release_candidate_version }}\"
+                    \"RELEASE_VERSION=${{ needs.define_version_job.outputs.version }}\"
                   ]
                 }
               }
@@ -64,24 +74,24 @@ jobs:
       REPO_NAME: datree
       IMAGE_NAME: datree
     name: Release container image to public registries
-    needs: release
+    needs: [release, define_version_job]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: docker/setup-buildx-action@v1
-    - name: Log in to DockerHub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Build and push to registries
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        platforms: linux/amd64
-        push: true
-        tags: |
-          ${{ env.REPO_NAME }}/${{ env.IMAGE_NAME }}:latest
-          ${{ env.REPO_NAME }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.release_candidate_version }}
-        cache-from: type=gha
-        cache-to: type=gha
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+      - name: Log in to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push to registries
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.REPO_NAME }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REPO_NAME }}/${{ env.IMAGE_NAME }}:${{ steps.define_version.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,12 +59,12 @@ jobs:
               -d "$BODY" \
               "https://api.travis-ci.com/repo/${GH_ORGANIZATION_NAME}%2F${GH_REPOSITORY_NAME}/requests"
 
-  docker-images:
+  release-docker:
     env:
       REPO_NAME: datree
       IMAGE_NAME: datree
       COMMIT_SHA: ${{ github.sha }}
-    name: Docker image build / push
+    name: Release container image to public registries
     needs: release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,10 @@ jobs:
       - uses: actions/checkout@v2
       - id: define_version
         name: Define release version
-        run: echo "##[set-output name=version;]$(bash ./scripts/define_release_version.sh ${{ github.event.inputs.release_candidate_version }})"
+        run: |-
+          OUTPUT_VERSION=$(bash scripts/define_release_version.sh ${{ github.event.inputs.release_candidate_version }})
+          echo "detected version = $OUTPUT_VERSION"
+          echo ::set-output name=version::$(echo $OUTPUT_VERSION)
     outputs:
       version: ${{ steps.define_version.outputs.version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,9 +74,6 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    #- uses: docker/setup-qemu-action@v1
-    #this should only be needed if building
-    #for other platforms like linux/arm64
     - name: Build and push to registries
       uses: docker/build-push-action@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,3 +58,42 @@ jobs:
               -H "Authorization: token ${TRAVIS_API_TOKEN}" \
               -d "$BODY" \
               "https://api.travis-ci.com/repo/${GH_ORGANIZATION_NAME}%2F${GH_REPOSITORY_NAME}/requests"
+
+  docker-images:
+    env:
+      REPO_NAME: datree
+      IMAGE_NAME: datree
+      COMMIT_SHA: ${{ github.sha }}
+    name: Docker image build / push
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: docker/setup-buildx-action@v1
+    - name: Log in to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Log in to GitHub Container Registry (ghcr.io)
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    #- uses: docker/setup-qemu-action@v1
+    #this should only be needed if building
+    #for other platforms like linux/arm64
+    - name: Build and push to registries
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        platforms: linux/amd64
+        push: true
+        tags: |
+          ${{ env.REPO_NAME }}/${{ env.IMAGE_NAME }}:latest
+          ${{ env.REPO_NAME }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.release_candidate_version }}
+          ghcr.io/${{ REPO_NAME }}/${{ env.IMAGE_NAME }}:latest
+          ghcr.io/${{ REPO_NAME }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.release_candidate_version }}
+        cache-from: type=gha
+        cache-to: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
         run: echo "##[set-output name=version;]$(bash ./scripts/define_release_version.sh ${{ github.event.inputs.release_candidate_version }})"
     outputs:
       version: ${{ steps.define_version.outputs.version }}
+
   release:
     runs-on: ubuntu-latest
     needs: define_version_job
@@ -92,6 +93,6 @@ jobs:
           push: true
           tags: |
             ${{ env.REPO_NAME }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.REPO_NAME }}/${{ env.IMAGE_NAME }}:${{ steps.define_version.outputs.version }}
+            ${{ env.REPO_NAME }}/${{ env.IMAGE_NAME }}:${{ needs.define_version_job.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha

--- a/scripts/define_release_version.sh
+++ b/scripts/define_release_version.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+if test -z "$1"; then
+    latestRcTag=$(git tag --sort=-version:refname | grep "\-rc$" | head -n 1)
+else
+    latestRcTag="$1"
+fi
+
+pattern="^[0-9]+\.[0-9]+\.[0-9]+\-rc$" 
+if [[ ! $latestRcTag =~ $pattern ]]; then
+    echo "release candidate does not match expected pattern"
+    exit 1
+fi
+
+release_tag=${latestRcTag%-rc}
+echo $release_tag

--- a/scripts/define_release_version.sh
+++ b/scripts/define_release_version.sh
@@ -7,7 +7,7 @@ else
     latestRcTag="$1"
 fi
 
-pattern="^[0-9]+\.[0-9]+\.[0-9]+\-rc$" 
+pattern="^[0-9]+\.[0-9]+\.[0-9]+\-rc$"
 if [[ ! $latestRcTag =~ $pattern ]]; then
     echo "release candidate does not match expected pattern"
     exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
 set -ex
 
-if test -z "$RELEASE_CANDIDATE_VERSION"; then
-    latestRcTag=$(git tag --sort=-version:refname | grep "\-rc$" | head -n 1)
-else
-    latestRcTag="$RELEASE_CANDIDATE_VERSION"
-fi
+release_tag=$RELEASE_VERSION
 
-if test -z "$latestRcTag"; then
-    echo "couldn't find latestRcTag"
-    exit 1
-fi
-echo $latestRcTag
+git checkout "$release_tag-rc"
 
-git checkout $latestRcTag
-
-release_tag=${latestRcTag%-rc}
 git tag $release_tag -a -m "Generated tag from manual TravisCI for production build $TRAVIS_BUILD_NUMBER"
 git push origin $release_tag # TODO: check if goreleaser pushes the tag itself (so no need to push here)
 


### PR DESCRIPTION
This resolves #250.

I have updated the manually triggered `release.yml` workflow. This workflow could be automatically triggered by another event such as cutting the release itself in GitHub if the team is interested in that as confidence in the build system grows and more automation makes sense.

Another suggestion I have is that for the earlier workflow Job speaking to Travis that's called `release`. We can validate the entered release tag with a regex to make sure the Action doesn't kick off if there's a typo in that user-provided string to avoid pushing builds with incorrect version tags. A basic semver check.

Those could be other issues with their own PRs - just some thoughts I had after looking at this.