### PR TITLE
feat: add workflow for assigning issues to project

### DIFF
--- a/.github/workflows/auto-assign-project.yaml
+++ b/.github/workflows/auto-assign-project.yaml
@@ -1,0 +1,20 @@
+name: Auto Assign to Project
+
+on:
+  issues:
+    types: [labeled]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to One Project
+    steps:
+    - name: Assign issues with `up for grabs` label to project `Datree`
+      uses: srggrs/assign-one-project-github-action@1.2.1
+      if: |
+        contains(github.event.issue.labels.*.name, 'up for grabs')
+      with:
+        project: 'https://github.com/datreeio/datree/projects/2'
+        column_name: 'To Do'


### PR DESCRIPTION
every issue with the label `up for grabs` will be auto-assigned to [Datree's project](https://github.com/datreeio/datree/projects/2) - `To Do` column
tested on my fork: https://github.com/eyarz/datree/