### PR TITLE
[Hackathon] Security best practices policy

### DIFF
--- a/examples/security-best-practices/README.md
+++ b/examples/security-best-practices/README.md
@@ -4,12 +4,14 @@ best practices such as setting user permissions and more. This policy requires t
 to be set to Pod, Deployment, StatefulSet or DaemonSet.
 
 __This policy helps to enforce the following security best practices:__
-* Ensuring the user permission is set
-* Ensuring the groups permission is set
-* Ensuring a privilege escalation flag is set
+* Ensure user permission is set
+* Ensure groups permission is set
+* Ensure privilege escalation is set
+* Ensure that filesystem accessibility is set
 
 ## Ensure user permission is set
-This flag controls which user ID the containers are run with. 
+This flag controls which user ID the containers are run with. If this value is 0, then
+the pod is run with non-root user.
 
 ### When this rule is failing?
 If the `runAsUser` key is missing from the securityContext section:  
@@ -20,7 +22,7 @@ spec:
     runAsUser: 1000
 ```
 
-__OR__ a invalid value of `runAsUser` is used:
+__OR__ an invalid value of `runAsUser` is used:
 ```
 kind: Pod
 spec:
@@ -42,7 +44,15 @@ spec:
     runAsGroup: 3000
 ```
 
-## Ensure privelege escalation is set
+__OR__ an invalid value of `runAsGroup` is used:
+```
+kind: Pod
+spec:
+  securityContext:
+    runAsGroup: -1
+```
+
+## Ensure privilege escalation is set
 This flag controls whether process can gain more privileges than it's parent process.
 It controls the `no_new_privs` flag which is set on the container process.
 
@@ -55,9 +65,23 @@ spec:
     allowPrivilegeEscalation: false
 ```
 
+## Ensure that filesystem accessibility is set
+Requires containers to run with a read-only root filesystem if set to true i.e. no
+writeable layer.
+
+### When this rule is failing?
+If the flag is not a boolean:
+```
+kind: Pod
+spec:
+  securityContext:
+    readOnlyRootFilesystem: false
+```
+
 ## Policy author
 Antariksh Verma \\ [yummyweb](https://github.com/yummyweb)
 
 ## Policy Sources
-- [Kubernetes Documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
-- [AquaSec Security Best Practices](https://www.aquasec.com/cloud-native-academy/kubernetes-in-production/kubernetes-security-best-practices-10-steps-to-securing-k8s/)
+- [Pod Security Policy Documentation](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
+- [Kubernetes Pod Configuration](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+- [Aqua Security Best Practices](https://www.aquasec.com/cloud-native-academy/kubernetes-in-production/kubernetes-security-best-practices-10-steps-to-securing-k8s/)

--- a/examples/security-best-practices/README.md
+++ b/examples/security-best-practices/README.md
@@ -1,0 +1,62 @@
+# Policy: security_best_practices
+This policy allows DevOps engineers or developers to enforce industry-standard recommended security
+best practices such as setting user permissions and more.
+
+__This policy helps to enforce the following security best practices:__
+* Ensuring the user permission is set
+* Ensuring the groups permission is set
+* Ensuring a privilege escalation flag is set
+
+## Ensure user permission is set
+This flag controls which user ID the containers are run with. 
+
+### When this rule is failing?
+If the `runAsUser` key is missing from the securityContext section:  
+```
+kind: Pod
+spec:
+  securityContext:
+    runAsUser: 1000
+```
+
+__OR__ a invalid value of `runAsUser` is used:
+```
+kind: Pod
+spec:
+  securityContext:
+    runAsUser: 11000
+```
+
+## Ensure groups permission is set
+The `runAsGroup` field controls how processes interact with files. If it was ommitted,
+the gid would remain as 0, and the process would be able to interact with files owned
+by root group.
+
+### When this rule is failing?
+If the `runAsGroup` key is missing from the securityContext section:  
+```
+kind: Pod
+spec:
+  securityContext:
+    runAsGroup: 3000
+```
+
+## Ensure privelege escalation is set
+This flag controls whether process can gain more privileges than it's parent process.
+It controls the `no_new_privs` flag which is set on the container process.
+
+### When this rule is failing?
+If the flag is not a boolean: 
+```
+kind: Pod
+spec:
+  securityContext:
+    allowPrivilegeEscalation: false
+```
+
+## Policy author
+Antariksh Verma \\ [yummyweb](https://github.com/yummyweb)
+
+## Policy Sources
+- [Kubernetes Documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+- [AquaSec Security Best Practices](https://www.aquasec.com/cloud-native-academy/kubernetes-in-production/kubernetes-security-best-practices-10-steps-to-securing-k8s/)

--- a/examples/security-best-practices/README.md
+++ b/examples/security-best-practices/README.md
@@ -1,6 +1,7 @@
 # Policy: security_best_practices
 This policy allows DevOps engineers or developers to enforce industry-standard recommended security
-best practices such as setting user permissions and more.
+best practices such as setting user permissions and more. This policy requires the `kind`
+to be set to Pod, Deployment or StatefulSet.
 
 __This policy helps to enforce the following security best practices:__
 * Ensuring the user permission is set

--- a/examples/security-best-practices/README.md
+++ b/examples/security-best-practices/README.md
@@ -1,7 +1,7 @@
 # Policy: security_best_practices
 This policy allows DevOps engineers or developers to enforce industry-standard recommended security
 best practices such as setting user permissions and more. This policy requires the `kind`
-to be set to Pod, Deployment or StatefulSet.
+to be set to Pod, Deployment, StatefulSet or DaemonSet.
 
 __This policy helps to enforce the following security best practices:__
 * Ensuring the user permission is set

--- a/examples/security-best-practices/README.md
+++ b/examples/security-best-practices/README.md
@@ -8,6 +8,7 @@ __This policy helps to enforce the following security best practices:__
 * Ensure groups permission is set
 * Ensure privilege escalation is set
 * Ensure that filesystem accessibility is set
+* Ensure deprecated resource is not used
 
 ## Ensure user permission is set
 This flag controls which user ID the containers are run with. If this value is 0, then
@@ -76,6 +77,17 @@ kind: Pod
 spec:
   securityContext:
     readOnlyRootFilesystem: false
+```
+
+## Ensure deprecated resource is not used
+PodSecurityPolicy is a type of resource that is deprecated in Kubernetes v1.21 and is
+set to be removed in Kubernetes v1.25. It is against security best practices and other
+resources can be used in favor of it such as Pod or Deployment.
+
+### When this rule is failing?
+If the `kind` field is set to PodSecurityPolicy:
+```
+kind: PodSecurityPolicy
 ```
 
 ## Policy author

--- a/examples/security-best-practices/README.md
+++ b/examples/security-best-practices/README.md
@@ -10,6 +10,7 @@ __This policy helps to enforce the following security best practices:__
 * Ensure that filesystem accessibility is set
 * Ensure deprecated resource is not used
 * Ensure privileged flag is set
+* Ensure that imagePullPolicy is set to Always
 
 ## Ensure user permission is set
 This flag controls which user ID the containers are run with. If this value is 0, then
@@ -114,6 +115,21 @@ spec:
     runAsUser: 1000
     runAsGroup: 1000
     allowPrivilegedEscalation: true
+```
+
+## Ensure that imagePullPolicy is set to Always
+The `imagePullPolicy` field for a container affect when the kubelet attempts to download
+the specified image. If the value is set to Always, then everytime the kubelet is launched
+the kubelet queries the container image and resolves the name to an image digest.
+
+### When this rule is failing?
+If the field is not Always:
+```
+kind: Pod
+spec:
+  containers:
+    - name: image
+      imagePullPolicy: Never
 ```
 
 ## Policy author

--- a/examples/security-best-practices/README.md
+++ b/examples/security-best-practices/README.md
@@ -9,6 +9,7 @@ __This policy helps to enforce the following security best practices:__
 * Ensure privilege escalation is set
 * Ensure that filesystem accessibility is set
 * Ensure deprecated resource is not used
+* Ensure privileged flag is set
 
 ## Ensure user permission is set
 This flag controls which user ID the containers are run with. If this value is 0, then
@@ -42,7 +43,8 @@ If the `runAsGroup` key is missing from the securityContext section:
 kind: Pod
 spec:
   securityContext:
-    runAsGroup: 3000
+    runAsUser: 1000
+    allowPrivilegedEscalation: false
 ```
 
 __OR__ an invalid value of `runAsGroup` is used:
@@ -88,6 +90,30 @@ resources can be used in favor of it such as Pod or Deployment.
 If the `kind` field is set to PodSecurityPolicy:
 ```
 kind: PodSecurityPolicy
+```
+
+## Ensure privileged flag is set
+The `privileged` flag allows a container to run in privileged mode where processes are
+essentially equivalent to root on the host. It also allows the process to access host's
+resources and devices.
+
+### When this rule is failing?
+If the flag is not a boolean:
+```
+kind: Pod
+spec:
+  securityContext:
+    privileged: not-false
+```
+
+__OR__ it is missing from the securityContext section:
+```
+kind: Pod
+spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    allowPrivilegedEscalation: true
 ```
 
 ## Policy author

--- a/examples/security-best-practices/fail.yaml
+++ b/examples/security-best-practices/fail.yaml
@@ -54,3 +54,20 @@ spec:
       image: nginx:1.14.2
       ports:
         - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Pod
+metadata:
+  name: fail-flex-volume
+spec:
+  securityContext:
+    runAsGroup: 1000
+    runAsUser: 1000
+  containers:
+    - name: nginx
+      image: nginx:1.14.2
+      ports:
+        - containerPort: 80
+  allowedFlexVolumes:
+    - driver: example/cifs
+    

--- a/examples/security-best-practices/fail.yaml
+++ b/examples/security-best-practices/fail.yaml
@@ -5,7 +5,7 @@ metadata:
   name: fail-user-permission
 spec:
   securityContext:
-    runAsUser: 11000
+    runAsUser: 1000
   containers:
   - name: nginx
     image: nginx:1.14.2

--- a/examples/security-best-practices/fail.yaml
+++ b/examples/security-best-practices/fail.yaml
@@ -39,3 +39,18 @@ spec:
     image: nginx:1.14.2
     ports:
     - containerPort: 80
+---
+apiVersion: apps/v1
+kind: PodSecurityPolicy
+metadata:
+  name: fail-deprecated
+spec:
+  securityContext:
+    runAsGroup: 1000
+    runAsUser: 0
+    allowPrivilegeEscalation: true
+  containers:
+    - name: nginx
+      image: nginx:1.14.2
+      ports:
+        - containerPort: 80

--- a/examples/security-best-practices/fail.yaml
+++ b/examples/security-best-practices/fail.yaml
@@ -2,11 +2,10 @@
 apiVersion: apps/v1
 kind: Pod
 metadata:
-  name: fail-environment-label
-  labels:
-    environment: qa
-    app: test
+  name: fail-user-permission
 spec:
+  securityContext:
+    runAsUser: 11000
   containers:
   - name: nginx
     image: nginx:1.14.2
@@ -16,11 +15,11 @@ spec:
 apiVersion: apps/v1
 kind: Pod
 metadata:
-  name: fail-owner-label
-  labels:
-    environment: prod
-    app: test
+  name: fail-group-permission
 spec:
+  securityContext:
+    allowPrivilegeEscalation: false
+    runAsUser: 0
   containers:
   - name: nginx
     image: nginx:1.14.2
@@ -30,12 +29,11 @@ spec:
 apiVersion: apps/v1
 kind: Pod
 metadata:
-  name: fail-valid-label-value
-  labels:
-    environment: prod
-    app: test
-    owner: test@datree.io
+  name: fail-privilege-escalation
 spec:
+  securityContext:
+    runAsGroup: 1000
+    runAsUser: 1000
   containers:
   - name: nginx
     image: nginx:1.14.2

--- a/examples/security-best-practices/fail.yaml
+++ b/examples/security-best-practices/fail.yaml
@@ -41,6 +41,21 @@ spec:
     - containerPort: 80
 ---
 apiVersion: apps/v1
+kind: Pod
+metadata:
+  name: fail-root-filesystem
+spec:
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    privileged: false
+  containers:
+    - name: nginx
+      image: nginx:1.14.2
+      ports:
+        - containerPort: 80
+---
+apiVersion: apps/v1
 kind: PodSecurityPolicy
 metadata:
   name: fail-deprecated
@@ -70,4 +85,18 @@ spec:
         - containerPort: 80
   allowedFlexVolumes:
     - driver: example/cifs
+---
+apiVersion: apps/v1
+kind: Pod
+metadata:
+  name: fail-proc-mount
+spec:
+  securityContext:
+    runAsUser: 0
+    allowPrivilegedEscalation: true
+  containers:
+    - name: nginx
+      image: nginx:1.14.2
+      ports:
+        - containerPost: 80
     

--- a/examples/security-best-practices/fail.yaml
+++ b/examples/security-best-practices/fail.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: apps/v1
-kind: Pod
+kind: Service
 metadata:
   name: fail-user-permission
 spec:

--- a/examples/security-best-practices/log.txt
+++ b/examples/security-best-practices/log.txt
@@ -1,0 +1,2 @@
+2021/12/12 09:50:38 Micro started
+2021/12/12 09:50:38 gotham-colors is not a plugin

--- a/examples/security-best-practices/log.txt
+++ b/examples/security-best-practices/log.txt
@@ -1,2 +1,2 @@
-2021/12/12 09:50:38 Micro started
-2021/12/12 09:50:38 gotham-colors is not a plugin
+2021/12/12 10:13:14 Micro started
+2021/12/12 10:13:14 gotham-colors is not a plugin

--- a/examples/security-best-practices/log.txt
+++ b/examples/security-best-practices/log.txt
@@ -1,2 +1,2 @@
-2021/12/12 10:13:14 Micro started
-2021/12/12 10:13:14 gotham-colors is not a plugin
+2021/12/12 10:14:28 Micro started
+2021/12/12 10:14:28 gotham-colors is not a plugin

--- a/examples/security-best-practices/log.txt
+++ b/examples/security-best-practices/log.txt
@@ -1,2 +1,0 @@
-2021/12/12 10:14:28 Micro started
-2021/12/12 10:14:28 gotham-colors is not a plugin

--- a/examples/security-best-practices/pass.yaml
+++ b/examples/security-best-practices/pass.yaml
@@ -10,6 +10,7 @@ spec:
     readOnlyRootFilesystem: false
     allowPrivilegeEscalation: false
     privileged: false
+    allowedProcMountTypes: DefaultProcMount
   volumes:
     - flexVolume
   allowedFlexVolumes:

--- a/examples/security-best-practices/pass.yaml
+++ b/examples/security-best-practices/pass.yaml
@@ -9,6 +9,7 @@ spec:
     runAsGroup: 1000
     readOnlyRootFilesystem: false
     allowPrivilegeEscalation: false
+    privileged: false
   containers:
   - name: nginx
     image: nginx:1.14.2

--- a/examples/security-best-practices/pass.yaml
+++ b/examples/security-best-practices/pass.yaml
@@ -2,40 +2,13 @@
 apiVersion: apps/v1
 kind: Pod
 metadata:
-  name: fail-environment-label
-  labels:
-    environment: qa
-    app: test
+  name: pass-security
 spec:
-  containers:
-  - name: nginx
-    image: nginx:1.14.2
-    ports:
-    - containerPort: 80
----
-apiVersion: apps/v1
-kind: Pod
-metadata:
-  name: fail-owner-label
-  labels:
-    environment: prod
-    app: test
-spec:
-  containers:
-  - name: nginx
-    image: nginx:1.14.2
-    ports:
-    - containerPort: 80
----
-apiVersion: apps/v1
-kind: Pod
-metadata:
-  name: fail-valid-label-value
-  labels:
-    environment: prod
-    app: test
-    owner: test@datree.io
-spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    readOnlyRootFilesystem: false
+    allowPrivilegeEscalation: false
   containers:
   - name: nginx
     image: nginx:1.14.2

--- a/examples/security-best-practices/pass.yaml
+++ b/examples/security-best-practices/pass.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Pod
+metadata:
+  name: pass-policy
+  labels:
+    owner: me
+    environment: prod
+    app: web
+spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    allowPrivilegeEscalation: false
+    fsGroup: 2000
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80

--- a/examples/security-best-practices/pass.yaml
+++ b/examples/security-best-practices/pass.yaml
@@ -10,6 +10,10 @@ spec:
     readOnlyRootFilesystem: false
     allowPrivilegeEscalation: false
     privileged: false
+  volumes:
+    - flexVolume
+  allowedFlexVolumes:
+    - driver: example/lvm
   containers:
   - name: nginx
     image: nginx:1.14.2

--- a/examples/security-best-practices/policy.yaml
+++ b/examples/security-best-practices/policy.yaml
@@ -15,7 +15,7 @@ customRules:
         properties:
           kind:
             enum:
-              - Pods
+              - Pod
       then:
         properties:
           spec:

--- a/examples/security-best-practices/policy.yaml
+++ b/examples/security-best-practices/policy.yaml
@@ -13,6 +13,8 @@ policies:
         messageOnFailure: ''
       - identifier: CUSTOM_SECURITY_DEPRECATED_CHECK
         messageOnFailure: ''
+      - idenitifer: CUSTOM_SECURITY_PRIVILEGED_CHECK
+        messageOnFailure: ''
 
 customRules:
   - identifier: CUSTOM_SECURITY_USER_CHECK
@@ -118,4 +120,27 @@ customRules:
           kind:
             enum:
               - PodSecurityPolicy
-    
+
+  - identifier: CUSTOM_SECURITY_PRIVILEGED_CHECK
+    name: Check for the privileged flag [CUSTOM RULE]
+    defaultMessageOnFailure: Add the privileged flag, ensure it is a boolean
+    schema:
+      properties:
+        kind:
+          enum:
+            - Pod
+            - Deployment
+            - StatefulSet
+            - DaemonSet
+        spec:
+          properties:
+            securityContext:
+              properties:
+                privileged:
+                  enum:
+                    - true
+                    - false
+              required:
+                - privileged
+          required:
+            - securityContext

--- a/examples/security-best-practices/policy.yaml
+++ b/examples/security-best-practices/policy.yaml
@@ -11,6 +11,8 @@ policies:
         messageOnFailure: ''
       - identifier: CUSTOM_SECURITY_FILESYSTEM_ACCESSIBILITY
         messageOnFailure: ''
+      - identifier: CUSTOM_SECURITY_DEPRECATED_CHECK
+        messageOnFailure: ''
 
 customRules:
   - identifier: CUSTOM_SECURITY_USER_CHECK
@@ -106,4 +108,14 @@ customRules:
                 - readOnlyRootFilesystem
           required:
             - securityContext
+
+  - identifier: CUSTOM_SECURITY_DEPRECATED_CHECK
+    name: Check for use of PodSecurityPolicy (Deprecated) [CUSTOM RULE]
+    defaultMessageOnFailure: Change the `kind` field from PodSecurityPolicy to Pod
+    schema:
+      not:
+        properties:
+          kind:
+            enum:
+              - PodSecurityPolicy
     

--- a/examples/security-best-practices/policy.yaml
+++ b/examples/security-best-practices/policy.yaml
@@ -3,13 +3,17 @@ policies:
   - name: security_best_practices
     isDefault: true
     rules:
-      - identifier: CUSTOM_SECURITY_CONTEXT_CHECK
+      - identifier: CUSTOM_SECURITY_USER_CHECK
+        messageOnFailure: ''
+      - identifier: CUSTOM_SECURITY_GROUPS_CHECK
+        messageOnFailure: ''
+      - identifier: CUSTOM_SECURITY_PRIVILEGE_CHECK
         messageOnFailure: ''
 
 customRules:
-  - identifier: CUSTOM_SECURITY_CONTEXT_CHECK
-    name: Check for basic security context rules [CUSTOM RULE]
-    defaultMessageOnFailure: Add all necessary security context rules (`runAsUser`, `runAsGroup` and `allowPrivelegeEscalation`)
+  - identifier: CUSTOM_SECURITY_USER_CHECK
+    name: Check for runAsUser field setting [CUSTOM RULE]
+    defaultMessageOnFailure: Add runAsUser setting, ensure it is a number between range 0 and 10000
     schema:
       if:
         properties:
@@ -25,16 +29,55 @@ customRules:
                   runAsUser:
                     minimum: 0
                     maximum: 10000
+                required:
+                  - runAsUser
+            required:
+              - securityContext
+
+  - identifier: CUSTOM_SECURITY_GROUPS_CHECK
+    name: Check for runAsGroup field setting [CUSTOM_RULE]
+    defaultMessageOnFailure: Add runAsGroup setting, ensure it is a number between range 0 and 10000
+    schema:
+      if:
+        properties:
+          kind:
+            enum:
+              - Pod
+      then:
+        properties:
+          spec:
+            properties:
+              securityContext:
+                properties:
                   runAsGroup:
                     minimum: 0
                     maximum: 10000
+                required:
+                  - runAsGroup
+            required:
+              - securityContext
+
+  - identifier: CUSTOM_SECURITY_PRIVILEGE_CHECK
+    name: Check for allowPrivilegeEscalation setting [CUSTOM_RULE]
+    defaultMessageOnFailure: Add allowPrivilegeEscalation setting, ensure it is a boolean
+    schema:
+      if:
+        properties:
+          kind:
+            enum:
+              - Pod
+      then:
+        properties:
+          spec:
+            properties:
+              securityContext:
+                properties:
                   allowPrivilegeEscalation:
                     enum:
-                      - false
                       - true
+                      - false
                 required:
-                  - runAsUser
-                  - runAsGroup
                   - allowPrivilegeEscalation
             required:
               - securityContext
+              

--- a/examples/security-best-practices/policy.yaml
+++ b/examples/security-best-practices/policy.yaml
@@ -15,96 +15,69 @@ customRules:
     name: Check for runAsUser field setting [CUSTOM RULE]
     defaultMessageOnFailure: Add runAsUser setting, ensure it is a number between range 0 and 10000
     schema:
-      if:
-        properties:
-          kind:
-            enum:
-              - Pod
-              - Deployment
-              - StatefulSet
-      then:
-        properties:
-          spec:
-            properties:
-              securityContext:
-                properties:
-                  runAsUser:
-                    minimum: 0
-                    maximum: 10000
-                required:
-                  - runAsUser
-            required:
-              - securityContext
-      else:
-        properties:
-          wrongkind:
-            enum:
-              - wrong
-        required:
-          - wrongkind
+      properties:
+        kind:
+          enum:
+            - Pod
+            - Deployment
+            - StatefulSet
+            - DaemonSet
+        spec:
+          properties:
+            securityContext:
+              properties:
+                runAsUser:
+                  minimum: 0
+                  maximum: 10000
+              required:
+                - runAsUser
+          required:
+            - securityContext
 
   - identifier: CUSTOM_SECURITY_GROUPS_CHECK
     name: Check for runAsGroup field setting [CUSTOM_RULE]
     defaultMessageOnFailure: Add runAsGroup setting, ensure it is a number between range 0 and 10000
     schema:
-      if:
-        properties:
-          kind:
-            enum:
-              - Pod
-              - Deployment
-              - StatefulSet
-      then:
-        properties:
-          spec:
-            properties:
-              securityContext:
-                properties:
-                  runAsGroup:
-                    minimum: 0
-                    maximum: 10000
-                required:
-                  - runAsGroup
-            required:
-              - securityContext
-      else:
-        properties:
-          wrongkind:
-            enum:
-              - wrong
-        required:
-          - wrongkind
+      properties:
+        kind:
+          enum:
+            - Pod
+            - Deployment
+            - StatefulSet
+            - DaemonSet
+        spec:
+          properties:
+            securityContext:
+              properties:
+                runAsGroup:
+                  minimum: 0
+                  maximum: 10000
+              required:
+                - runAsGroup
+          required:
+            - securityContext
 
   - identifier: CUSTOM_SECURITY_PRIVILEGE_CHECK
     name: Check for allowPrivilegeEscalation setting [CUSTOM_RULE]
     defaultMessageOnFailure: Add allowPrivilegeEscalation setting, ensure it is a boolean
     schema:
-      if:
-        properties:
-          kind:
-            enum:
-              - Pod
-              - Deployment
-              - StatefulSet
-      then:
-        properties:
-          spec:
-            properties:
-              securityContext:
-                properties:
-                  allowPrivilegeEscalation:
-                    enum:
-                      - true
-                      - false
-                required:
-                  - allowPrivilegeEscalation
-            required:
-              - securityContext
-      else:
-        properties:
-          wrongkind:
-            enum:
-              - wrong
-        required:
-          - wrongkind
+      properties:
+        kind:
+          enum:
+            - Pod
+            - Deployment
+            - StatefulSet
+            - DaemonSet
+        spec:
+          properties:
+            securityContext:
+              properties:
+                allowPrivilegeEscalation:
+                  enum:
+                    - true
+                    - false
+              required:
+                - allowPrivilegeEscalation
+          required:
+            - securityContext
               

--- a/examples/security-best-practices/policy.yaml
+++ b/examples/security-best-practices/policy.yaml
@@ -15,6 +15,8 @@ policies:
         messageOnFailure: ''
       - idenitifer: CUSTOM_SECURITY_PRIVILEGED_CHECK
         messageOnFailure: ''
+      - identifier: CUSTOM_SECURITY_IMAGE_PULL
+        messageOnFailure: ''
 
 customRules:
   - identifier: CUSTOM_SECURITY_USER_CHECK
@@ -144,3 +146,24 @@ customRules:
                 - privileged
           required:
             - securityContext
+
+  - identifier: CUSTOM_SECURITY_IMAGE_PULL
+    name: Ensure imagePullPolicy is set to always [CUSTOM RULE]
+    defaultMessageOnFailure:
+    schema:
+      properties:
+        kind:
+          enum:
+            - Pod
+            - Deployment
+            - StatefulSet
+            - DaemonSet
+        spec:
+          properties:
+            containers:
+              type: array
+              items:
+                properties:
+                  imagePullPolicy:
+                    enum:
+                      - Always

--- a/examples/security-best-practices/policy.yaml
+++ b/examples/security-best-practices/policy.yaml
@@ -20,6 +20,8 @@ customRules:
           kind:
             enum:
               - Pod
+              - Deployment
+              - StatefulSet
       then:
         properties:
           spec:
@@ -33,6 +35,13 @@ customRules:
                   - runAsUser
             required:
               - securityContext
+      else:
+        properties:
+          wrongkind:
+            enum:
+              - wrong
+        required:
+          - wrongkind
 
   - identifier: CUSTOM_SECURITY_GROUPS_CHECK
     name: Check for runAsGroup field setting [CUSTOM_RULE]
@@ -43,6 +52,8 @@ customRules:
           kind:
             enum:
               - Pod
+              - Deployment
+              - StatefulSet
       then:
         properties:
           spec:
@@ -56,6 +67,13 @@ customRules:
                   - runAsGroup
             required:
               - securityContext
+      else:
+        properties:
+          wrongkind:
+            enum:
+              - wrong
+        required:
+          - wrongkind
 
   - identifier: CUSTOM_SECURITY_PRIVILEGE_CHECK
     name: Check for allowPrivilegeEscalation setting [CUSTOM_RULE]
@@ -66,6 +84,8 @@ customRules:
           kind:
             enum:
               - Pod
+              - Deployment
+              - StatefulSet
       then:
         properties:
           spec:
@@ -80,4 +100,11 @@ customRules:
                   - allowPrivilegeEscalation
             required:
               - securityContext
+      else:
+        properties:
+          wrongkind:
+            enum:
+              - wrong
+        required:
+          - wrongkind
               

--- a/examples/security-best-practices/policy.yaml
+++ b/examples/security-best-practices/policy.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+policies:
+  - name: security_best_practices
+    isDefault: true
+    rules:
+      - identifier: CUSTOM_SECURITY_CONTEXT_CHECK
+        messageOnFailure: ''
+
+customRules:
+  - identifier: CUSTOM_SECURITY_CONTEXT_CHECK
+    name: Check for basic security context rules [CUSTOM RULE]
+    defaultMessageOnFailure: Add all necessary security context rules (`runAsUser`, `runAsGroup` and `allowPrivelegeEscalation`)
+    schema:
+      if:
+        properties:
+          kind:
+            enum:
+              - Pods
+      then:
+        properties:
+          spec:
+            properties:
+              securityContext:
+                properties:
+                  runAsUser:
+                    minimum: 0
+                    maximum: 10000
+                  runAsGroup:
+                    minimum: 0
+                    maximum: 10000
+                  allowPrivilegeEscalation:
+                    enum:
+                      - false
+                      - true
+                required:
+                  - runAsUser
+                  - runAsGroup
+                  - allowPrivilegeEscalation
+            required:
+              - securityContext

--- a/examples/security-best-practices/policy.yaml
+++ b/examples/security-best-practices/policy.yaml
@@ -13,9 +13,11 @@ policies:
         messageOnFailure: ''
       - identifier: CUSTOM_SECURITY_DEPRECATED_CHECK
         messageOnFailure: ''
-      - idenitifer: CUSTOM_SECURITY_PRIVILEGED_CHECK
+      - identifier: CUSTOM_SECURITY_PRIVILEGED_CHECK
         messageOnFailure: ''
       - identifier: CUSTOM_SECURITY_IMAGE_PULL
+        messageOnFailure: ''
+      - identifier: CUSTOM_SECURITY_FLEX_VOLUME_CHECK
         messageOnFailure: ''
 
 customRules:
@@ -149,7 +151,7 @@ customRules:
 
   - identifier: CUSTOM_SECURITY_IMAGE_PULL
     name: Ensure imagePullPolicy is set to always [CUSTOM RULE]
-    defaultMessageOnFailure:
+    defaultMessageOnFailure: Set imagePullPolicy to Always
     schema:
       properties:
         kind:
@@ -167,3 +169,23 @@ customRules:
                   imagePullPolicy:
                     enum:
                       - Always
+
+  - identifier: CUSTOM_SECURITY_FLEX_VOLUME_CHECK
+    name: Check for the presence of flexVolume when allowedFlexVolumes is declared [CUSTOM RULE]
+    defaultMessageOnFailure: Ensure allowedFlexVolumes is present
+    schema:
+      if:
+        properties:
+          spec:
+            required:
+              - allowedFlexVolumes
+      then:
+        properties:
+          spec:
+            properties:
+              volumes:
+                type: array
+                contains:
+                  const: flexVolume
+            required:
+              - volumes

--- a/examples/security-best-practices/policy.yaml
+++ b/examples/security-best-practices/policy.yaml
@@ -9,6 +9,8 @@ policies:
         messageOnFailure: ''
       - identifier: CUSTOM_SECURITY_PRIVILEGE_CHECK
         messageOnFailure: ''
+      - identifier: CUSTOM_SECURITY_FILESYSTEM_ACCESSIBILITY
+        messageOnFailure: ''
 
 customRules:
   - identifier: CUSTOM_SECURITY_USER_CHECK
@@ -35,7 +37,7 @@ customRules:
             - securityContext
 
   - identifier: CUSTOM_SECURITY_GROUPS_CHECK
-    name: Check for runAsGroup field setting [CUSTOM_RULE]
+    name: Check for runAsGroup field setting [CUSTOM RULE]
     defaultMessageOnFailure: Add runAsGroup setting, ensure it is a number between range 0 and 10000
     schema:
       properties:
@@ -58,7 +60,7 @@ customRules:
             - securityContext
 
   - identifier: CUSTOM_SECURITY_PRIVILEGE_CHECK
-    name: Check for allowPrivilegeEscalation setting [CUSTOM_RULE]
+    name: Check for allowPrivilegeEscalation setting [CUSTOM RULE]
     defaultMessageOnFailure: Add allowPrivilegeEscalation setting, ensure it is a boolean
     schema:
       properties:
@@ -80,4 +82,28 @@ customRules:
                 - allowPrivilegeEscalation
           required:
             - securityContext
-              
+
+  - identifier: CUSTOM_SECURITY_FILESYSTEM_ACCESSIBILITY
+    name: Check for readOnlyRootFilesystem setting [CUSTOM RULE]
+    defaultMessageOnFailure: Add readOnlyRootFilesystem setting, ensure it is a boolean
+    schema:
+      properties:
+        kind:
+          enum:
+            - Pod
+            - Deployment
+            - StatefulSet
+            - DaemonSet
+        spec:
+          properties:
+            securityContext:
+              properties:
+                readOnlyRootFilesystem:
+                  enum:
+                    - true
+                    - false
+              required:
+                - readOnlyRootFilesystem
+          required:
+            - securityContext
+    

--- a/examples/security-best-practices/policy.yaml
+++ b/examples/security-best-practices/policy.yaml
@@ -19,6 +19,8 @@ policies:
         messageOnFailure: ''
       - identifier: CUSTOM_SECURITY_FLEX_VOLUME_CHECK
         messageOnFailure: ''
+      - identifier: CUSTOM_SECURITY_PROC_MOUNT_CHECK
+        messageOnFailure: ''
 
 customRules:
   - identifier: CUSTOM_SECURITY_USER_CHECK
@@ -189,3 +191,22 @@ customRules:
                   const: flexVolume
             required:
               - volumes
+
+  - identifier: CUSTOM_SECURITY_PROC_MOUNT_CHECK
+    name: Check for presence of allowedProcMountTypes [CUSTOM RULE]
+    defaultMessageOnFailure: Ensure `allowedProcMountTypes` field is present in `securityContext`
+    schema:
+      properties:
+        kind:
+          enum:
+            - Pod
+            - Deployment
+            - StatefulSet
+            - DaemonSet
+        spec:
+          properties:
+            securityContext:
+              required:
+                - allowedProcMountTypes
+          required:
+            - securityContext


### PR DESCRIPTION
## What
This PR adds an example of a security best practices policy. This policy checks the presence of certain fields like `runAsUser` and `runAsGroup`. Using this policy, DevOps engineers are able to handle permissions and accessibility of their clusters and containers.

## Why
This policy is based off of the Kubernetes documentation and certain articles of what constitutes as security best practices. One core aspect of Kubernetes security is `securityContext`. This PR is based on `securityContext` and allows Kubernetes engineers to handle permissions and accessibilities of their clusters and the containers within it. From the documentation, `securityContext` defines and manages privileges and access control settings.