### PR TITLE
[Hackathon] Custom policy to check if configuration file consist the name of the deployment

### DIFF
--- a/examples/workload-best-practices/README.md
+++ b/examples/workload-best-practices/README.md
@@ -1,0 +1,37 @@
+# Policy: industry_best_practices
+Kuberenets configuration files are made out of a specified structure. Although this structure can be tweeked by the developers according to their usecase. Kuberenetes labels helps engineers a lot to structure these configuration file into easy and human readable format.
+
+__This policy helps to enforce the following labels best practices:__
+* Ensure each configuration file has deployment name.
+
+## Ensure each configuration file has apiVersion label
+While starting the configuration it's essential to make sure that there is `name` specified for the deployment. Not having this might not raise errors by the native development kits (kubectl etc) but naming the deployment configurations while working with several clusters in a team is essential and cosidered a good practice. 
+* `name: demo-application-deployment`
+
+### When this rule is failing?
+If the `apiVersion` tag is not included at the starting of the configuration file
+```
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    owner: hello
+```
+
+### When this rule pass?
+The policy passes when provided with `apiVersion` at starting of the file
+```
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-application-deployment
+  labels:
+    owner: hello
+```
+
+```
+## Policy author
+Kaiwalya Koparkar \\ [kaiwalyakoparkar](https://github.com/kaiwalyakoparkar)
+Ashwin Kumar Uppala \\ [ashwinexe](https://github.com/ashwinexe)
+Karuna Tata \\ [starlightknown](https://github.com/starlightknown)
+Abhishek Choudhary \\ [shreemaan-abhishek](https://github.com/shreemaan-abhishek)

--- a/examples/workload-best-practices/README.md
+++ b/examples/workload-best-practices/README.md
@@ -9,7 +9,7 @@ While starting the configuration it's essential to make sure that there is `name
 * `name: demo-application-deployment`
 
 ### When this rule is failing?
-If the `apiVersion` tag is not included at the starting of the configuration file
+If the `name` tag is not included in the file (Generally under `metadata`)
 ```
 apiVersion: apps/v1
 kind: Deployment
@@ -19,7 +19,7 @@ metadata:
 ```
 
 ### When this rule pass?
-The policy passes when provided with `apiVersion` at starting of the file
+The policy passes when provided with `name` of the deployment.
 ```
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/workload-best-practices/fail.yaml
+++ b/examples/workload-best-practices/fail.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: Pod
+metadata:
+  labels:
+    environment: qa
+    app: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Pod
+metadata:
+  labels:
+    environment: prod
+    app: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Pod
+metadata:
+  labels:
+    environment: prod
+    app: test
+    owner: test@datree.io
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80

--- a/examples/workload-best-practices/pass.yaml
+++ b/examples/workload-best-practices/pass.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: apps/v1
+kind: Pod
+metadata:
+  name: pass-policy
+  labels:
+    owner: me
+    environment: prod
+    app: web
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80

--- a/examples/workload-best-practices/policy.yaml
+++ b/examples/workload-best-practices/policy.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+policies:
+  - name: workload_best_practices
+    isDefault: true
+    rules:
+      - identifier: CUSTOM_WORKLOAD_CHECK_NAME_LABEL
+        messageOnFailure: ''
+
+customRules:
+  - identifier: CUSTOM_WORKLOAD_CHECK_NAME_LABEL
+    name: Ensure each configuration file has deployment name.
+    defaultMessageOnFailure: Use `name` tag in the configuration file.
+    schema:
+      properties:
+        metadata:
+          required:
+            - name


### PR DESCRIPTION
## What
While starting the configuration it's essential to make sure that there is `name` specified for the deployment.

## Why
Not having this might not raise errors by the native development kits (kubectl etc) but naming the deployment configurations while working with several clusters in a team is essential and cosidered a good practice. 