### PR TITLE
[Hackathon] Policy to check Containers State

### DIFF
--- a/examples/container policy check/README.md
+++ b/examples/container policy check/README.md
@@ -1,0 +1,46 @@
+# Policy: Containers_best_practices
+
+Pods are the smallest units of deployable ,which you can create and manage in Kubernetes.
+A Pod is a group of one or more containers, with shared storage and network resources, and 
+a specification  to run the containers. 
+
+As Pod contain different Phase State i,e.. Pending,Running,Succeded,Failed and Unknown.
+
+# What are Container states?
+
+As Kubernetes tracks the state of each container inside a Pod.
+Once the scheduler assigns a Pod the kubelet starts creating containers for 
+that Pod using a container runtime. There are three possible container states: Waiting, Running, and Terminated.
+
+This Policy helps to verify the containers State.
+
+Ensure that each container has its correct state which are used.
+Ensure that each containers has a configured with running status that indicates the container is executing without issues.
+Ensure containers has valid its valid state.
+
+# When this rule is failing?
+
+If the environment key is missing from the labels section or if a different environment value is used.
+
+# Ensure that each container has its correct state which are used (mentioned below):
+
+
+* When it is in `Waiting` State':
+If a container is not in either the Running or Terminated state, 
+it is Waiting. A container in the Waiting state is still running the operations it requires in order to complete.
+
+* When it is in `Running` State: 
+The Running state indicates that a container is executing.
+
+* When it is in `Terminated` State':
+A container in the Terminated state began execution and then either ran to completion or failed for some reason.
+
+
+
+# Ensure that each containers has a configured with running status that indicates the container is executing without issues.
+
+defaultMessageOnFailure: Containers stop executing as running state failed.
+
+# Ensure containers has valid its valid state.
+
+defaultMessageOnFailure: Accept only approved container states (`waiting`, `running` and `terminated`)

--- a/examples/container policy check/README.md
+++ b/examples/container policy check/README.md
@@ -19,7 +19,13 @@ Ensure containers has valid its valid state.
 
 # When this rule is failing?
 
-If the environment key is missing from the labels section or if a different environment value is used.
+*If the environment key is missing from the labels section or if a different environment value is used.
+
+*This policy fails when it could not find appropriate container state label during container running.
+
+# When this policy is Pass?
+
+* This policy will pass when state includes information like the container’s sate label for each process.
 
 # Ensure that each container has its correct state which are used (mentioned below):
 

--- a/examples/container policy check/README.md
+++ b/examples/container policy check/README.md
@@ -1,18 +1,17 @@
 # Policy: Containers_best_practices
 
 Pods are the smallest units of deployable ,which you can create and manage in Kubernetes.
-A Pod is a group of one or more containers, with shared storage and network resources, and 
-a specification  to run the containers. 
 
 As Pod contain different Phase State i,e.. Pending,Running,Succeded,Failed and Unknown.
 
 # What are Container states?
 
 As Kubernetes tracks the state of each container inside a Pod.
-Once the scheduler assigns a Pod the kubelet starts creating containers for 
+A scheduler assigns a Pod that starts creating containers for 
 that Pod using a container runtime. There are three possible container states: Waiting, Running, and Terminated.
 
-This Policy helps to verify the containers State.
+It helps to easily identify the Containers state label and verify the correct state and have a valid state,
+A failed or terminated state gives an error.
 
 Ensure that each container has its correct state which are used.
 Ensure that each containers has a configured with running status that indicates the container is executing without issues.

--- a/examples/container policy check/fail.yaml
+++ b/examples/container policy check/fail.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apps/v1
+kind: Pod
+metadata:
+  name: failed-waiting-state
+  labels:
+    environment: qa
+    app: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    podphase: end
+    ports:
+    - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Pod
+metadata:
+  name: failed-running-state
+  labels:
+    environment: prod
+    app: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Pod
+metadata:
+  name: failed-terminated-state
+  labels:
+    environment: prod
+    app: test
+    owner: test@datree.io
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80

--- a/examples/container policy check/pass.yaml
+++ b/examples/container policy check/pass.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apps/v1
+kind: Pod
+metadata:
+  name: pass-policy
+  labels:
+    owner: me
+    environment: prod
+    app: web
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    containerstate: Running
+    ports:
+    - containerPort: 80

--- a/examples/container policy check/policy.yaml
+++ b/examples/container policy check/policy.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+policies:
+  - name: container_best_practices
+    isDefault: true
+    rules:
+      - identifier: CUSTOM_CONTAINERS_FAILED_STATE
+        messageOnFailure: ''
+      - identifier: CUSTOM_CONTAINERS_MISSING_STATE
+        messageOnFailure: ''
+      - identifier: CUSTOM_CONTAINERS_INVALID_STATE
+        messageOnFailure: ''
+
+customRules:
+  - identifier: CUSTOM_CONTAINERS_FAILED_STATE
+    name: Ensure that each container has its correct state which are used [CUSTOM RULE]
+    defaultMessageOnFailure: Accept only approved container states (`waiting`, `running` and `terminated`)
+    schema:
+      properties:
+        kind:
+          metadata:
+            properties:
+              labels:
+                properties:
+                  environment:
+                    containers:
+                      type: array
+                        enum:
+                          - waiting
+                          - running
+                          - terminated
+              required:
+                - environment
+          required:
+            - containers
+
+  - identifier: CUSTOM_CONTAINERS_MISSING_STATE
+    name: Ensure that each containers has a configured with running status that indicates the container is executing without issues. [CUSTOM RULE]
+    defaultMessageOnFailure: Containers stop executing as running state failed.
+    schema:
+      properties:
+        metadata:
+          properties:
+            labels:
+              required:
+                - owner
+          required:
+            - labels
+
+  - identifier: CUSTOM_CONTAINERS_INVALID_STATE
+    name: Ensure containers has valid its valid state. [CUSTOM RULE]
+    defaultMessageOnFailure: Accept only approved container states (`waiting`, `running` and `terminated`)
+    schema:
+      properties:
+        metadata:
+          properties:
+            labels:
+              patternProperties:
+                ^.*$:
+                  format: hostname
+              additionalProperties: false


### PR DESCRIPTION
# What?

`Containers_best_practices` Policy check. These Container state is reported by Kubernetes
to check containers image state label during of the process of running the container .



# Why?

It helps to easily identify the Containers state label and  verify the correct state and have a valid state,
 A failed or terminated state gives an error.

lets say an example whenever a user try to run container as an image is still running the some kind of operations and requires more time to complete  then it undergoes in `waiting state`.While executing the containers image it is in `running State`.

If the state shows as a `terminated state` ,it a failed situation of running container as image.

