### PR TITLE
fix: show k8s schema validation error messages on each line separate

### DIFF
--- a/bl/validation/k8sValidator.go
+++ b/bl/validation/k8sValidator.go
@@ -125,8 +125,15 @@ func (val *K8sValidator) validateResource(filepath string) (bool, []error, error
 		// File starts with ---, the parser assumes a first empty resource
 		if res.Status == kubeconformValidator.Invalid || res.Status == kubeconformValidator.Error {
 			isValid = false
-			errorMessage := strings.ReplaceAll(res.Err.Error(), "-", "\n   ")
-			validationErrors = append(validationErrors, &InvalidK8sSchemaError{ErrorMessage: errorMessage})
+			errorMessages := strings.Split(res.Err.Error(), "-")
+
+			// errorMessages slice is not empty
+			if len(errorMessages) > 0 {
+				for _, errorMessage := range errorMessages {
+					msg := strings.Trim(errorMessage, " ")
+					validationErrors = append(validationErrors, &InvalidK8sSchemaError{ErrorMessage: msg})
+				}
+			}
 		}
 	}
 

--- a/bl/validation/k8sValidator.go
+++ b/bl/validation/k8sValidator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/datreeio/datree/pkg/extractor"
 	kubeconformValidator "github.com/yannh/kubeconform/pkg/validator"
@@ -112,7 +113,7 @@ func (val *K8sValidator) validateResource(filepath string) (bool, []error, error
 
 	// Return an error if no valid configurations found
 	// Empty files are throwing errors in k8s
-	if len(results) == 1 && results[0].Status == kubeconformValidator.Empty{
+	if len(results) == 1 && results[0].Status == kubeconformValidator.Empty {
 		return false, []error{&InvalidK8sSchemaError{ErrorMessage: "empty file"}}, nil
 	}
 
@@ -124,7 +125,8 @@ func (val *K8sValidator) validateResource(filepath string) (bool, []error, error
 		// File starts with ---, the parser assumes a first empty resource
 		if res.Status == kubeconformValidator.Invalid || res.Status == kubeconformValidator.Error {
 			isValid = false
-			validationErrors = append(validationErrors, &InvalidK8sSchemaError{ErrorMessage: res.Err.Error()})
+			errorMessage := strings.ReplaceAll(res.Err.Error(), "-", "\n   ")
+			validationErrors = append(validationErrors, &InvalidK8sSchemaError{ErrorMessage: errorMessage})
 		}
 	}
 

--- a/bl/validation/main.go
+++ b/bl/validation/main.go
@@ -10,7 +10,7 @@ type InvalidK8sSchemaError struct {
 }
 
 func (e *InvalidK8sSchemaError) Error() string {
-	return fmt.Sprintf("k8s schema validation error: %s\n%s", e.ErrorMessage, e.usageSuggestion())
+	return fmt.Sprintf("k8s schema validation error:\n    %s\n%s", e.ErrorMessage, e.usageSuggestion())
 }
 
 func (e *InvalidK8sSchemaError) usageSuggestion() string {

--- a/bl/validation/main.go
+++ b/bl/validation/main.go
@@ -10,7 +10,7 @@ type InvalidK8sSchemaError struct {
 }
 
 func (e *InvalidK8sSchemaError) Error() string {
-	return fmt.Sprintf("k8s schema validation error:\n    %s\n%s", e.ErrorMessage, e.usageSuggestion())
+	return fmt.Sprintf("k8s schema validation error: %s\n%s", e.ErrorMessage, e.usageSuggestion())
 }
 
 func (e *InvalidK8sSchemaError) usageSuggestion() string {


### PR DESCRIPTION
Fixes #350 

**Changes Proposed in PR:**
- In order to print structured error output I have added a new line in `func (e *InvalidK8sSchemaError) Error() string` method.
- Inside `ValidateResource` method replacing `-` with newline.

**Testing Instructions**
1. Create a yaml file with below content.
```yaml
apiVersion: v1
kind: pod
metaData:
  name: static-web
  labels:
    role: myrole
spec:
  containers:
    - name: web
      mage: nginx
      ports:
        - name: web
          containerPort: 80
          protocol: TCP

```
2. checkout to this branch
3.  build project
4. now run `./datree test <test-config.yaml`
5. Verify each error is coming on separate line.

**Screenshots**
<img width="782" alt="Screenshot 2022-01-03 at 2 26 42 AM" src="https://user-images.githubusercontent.com/21127788/147889424-d4df5e27-9721-4be3-b9d3-ec3cf7d02571.png">

cc @myishay @eyarz 