### PR TITLE
feat: replace yaml pkg with `sigs.k8s.io/yaml`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/yannh/kubeconform v0.4.8
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+	sigs.k8s.io/yaml v1.2.0
 )
 
 require (
@@ -49,5 +50,4 @@ require (
 	golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 // indirect
 	golang.org/x/text v0.3.3 // indirect
 	gopkg.in/ini.v1 v1.51.0 // indirect
-	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/pkg/extractor/extractor.go
+++ b/pkg/extractor/extractor.go
@@ -1,11 +1,9 @@
 package extractor
 
 import (
-	"bytes"
-	"io"
 	"os"
 
-	"gopkg.in/yaml.v3"
+    "sigs.k8s.io/yaml"
 )
 
 type FileReader interface {
@@ -31,24 +29,15 @@ func ParseYaml(content string) (*[]Configuration, error) {
 func extractYamlConfigurations(content string) (*[]Configuration, error) {
 	var configurations []Configuration
 
-	yamlDecoder := yaml.NewDecoder(bytes.NewReader([]byte(content)))
+	jsonByte, err := yaml.YAMLToJSON([]byte(content)) 
 
-	var err error
-	for {
 		var doc = map[string]interface{}{}
-		err = yamlDecoder.Decode(&doc)
-		if err != nil {
-			break
-		}
+		err = yaml.Unmarshal(jsonByte, &doc)
 
 		if len(doc) > 0 {
 			configurations = append(configurations, doc)
 		}
-	}
 
-	if err == io.EOF {
-		err = nil
-	}
 
 	return &configurations, err
 }

--- a/pkg/extractor/extractor.go
+++ b/pkg/extractor/extractor.go
@@ -31,6 +31,10 @@ func extractYamlConfigurations(content string) (*[]Configuration, error) {
 
 	jsonByte, err := yaml.YAMLToJSON([]byte(content))
 
+	if err != nil {
+		return &configurations, err
+	}
+
 	var doc = map[string]interface{}{}
 	err = yaml.Unmarshal(jsonByte, &doc)
 

--- a/pkg/extractor/extractor.go
+++ b/pkg/extractor/extractor.go
@@ -3,7 +3,7 @@ package extractor
 import (
 	"os"
 
-    "sigs.k8s.io/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 type FileReader interface {
@@ -29,15 +29,14 @@ func ParseYaml(content string) (*[]Configuration, error) {
 func extractYamlConfigurations(content string) (*[]Configuration, error) {
 	var configurations []Configuration
 
-	jsonByte, err := yaml.YAMLToJSON([]byte(content)) 
+	jsonByte, err := yaml.YAMLToJSON([]byte(content))
 
-		var doc = map[string]interface{}{}
-		err = yaml.Unmarshal(jsonByte, &doc)
+	var doc = map[string]interface{}{}
+	err = yaml.Unmarshal(jsonByte, &doc)
 
-		if len(doc) > 0 {
-			configurations = append(configurations, doc)
-		}
-
+	if len(doc) > 0 {
+		configurations = append(configurations, doc)
+	}
 
 	return &configurations, err
 }


### PR DESCRIPTION
Fixes #377 
cc @noaabarki 

> Replace "gopkg.in/yaml.v3" with “https://github.com/kubernetes-sigs/yaml” in bl/files.go -> ExtractFilesConfigurations() and use YAMLToJSON to extract Kubernetes configurations from the files in the given path.

**Changes proposed in the PR:**
Replaced `yaml.Decoder` with `YAMLToJSON`
Correct place of replacement is here
https://github.com/datreeio/datree/blob/4c5bdff01f44fbb946d309794e11085acda3c115/pkg/extractor/extractor.go#L34


**Testing instructions**
1. checkout to this branch
2. build the project
3. test any yaml file
4. compare and validate current and branch results are same

**Screenshot**
![image](https://user-images.githubusercontent.com/21127788/150644135-55f7f8cf-df23-4e6c-a187-8479127c13c3.png)
