### PR TITLE
feat: print version message as a part of prerune hook

### DIFF
--- a/bl/messager/messager.go
+++ b/bl/messager/messager.go
@@ -26,7 +26,8 @@ type VersionMessage struct {
 	MessageColor string
 }
 
-func (m *Messager) LoadVersionMessages(messages chan *VersionMessage, cliVersion string) {
+func (m *Messager) LoadVersionMessages(cliVersion string) chan *VersionMessage {
+	messages := make(chan *VersionMessage, 1)
 	go func() {
 		msg, _ := m.messagesClient.GetVersionMessage(cliVersion, 900)
 		if msg != nil {
@@ -34,6 +35,7 @@ func (m *Messager) LoadVersionMessages(messages chan *VersionMessage, cliVersion
 		}
 		close(messages)
 	}()
+	return messages
 }
 
 func (m *Messager) toVersionMessage(msg *cliClient.VersionMessage) *VersionMessage {

--- a/bl/messager/messenger_test.go
+++ b/bl/messager/messenger_test.go
@@ -50,9 +50,7 @@ func TestLoadVersionMessages(t *testing.T) {
 				defaultTimeout: tt.mock.timeout,
 				messagesClient: mockedMessagesClient,
 			}
-			messager.LoadVersionMessages(tt.args.messagesChan, tt.args.cliVersion)
-
-			msg := <-tt.args.messagesChan
+			msg := <-messager.LoadVersionMessages(tt.args.cliVersion)
 
 			if tt.mock.message != nil {
 				assert.Equal(t, tt.mock.message.CliVersion, msg.CliVersion)

--- a/cmd/config/main.go
+++ b/cmd/config/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Messager interface {
-	LoadVersionMessages(messages chan *messager.VersionMessage, cliVersion string)
+	LoadVersionMessages(cliVersion string) chan *messager.VersionMessage
 }
 
 type Printer interface {

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/datreeio/datree/bl/messager"
 	"github.com/spf13/cobra"
 )
 
@@ -15,8 +14,7 @@ func NewSetCommand(ctx *ConfigCommandContext) *cobra.Command {
 		Short: "Set configuration value",
 		Long:  `Apply value for specific key in datree config.yaml file. Defaults to $HOME/.datree/config.yaml`,
 		Run: func(cmd *cobra.Command, args []string) {
-			messages := make(chan *messager.VersionMessage, 1)
-			go ctx.Messager.LoadVersionMessages(messages, ctx.CliVersion)
+			messages := ctx.Messager.LoadVersionMessages(ctx.CliVersion)
 
 			err := set(ctx, args[0], args[1])
 			if err != nil {

--- a/cmd/config/set_test.go
+++ b/cmd/config/set_test.go
@@ -13,7 +13,8 @@ type mockMessager struct {
 	mock.Mock
 }
 
-func (m *mockMessager) LoadVersionMessages(messages chan *messager.VersionMessage, cliVersion string) {
+func (m *mockMessager) LoadVersionMessages(cliVersion string) chan *messager.VersionMessage {
+	messages := make(chan *messager.VersionMessage, 1)
 	go func() {
 		messages <- &messager.VersionMessage{
 			CliVersion:   "1.2.3",
@@ -23,6 +24,7 @@ func (m *mockMessager) LoadVersionMessages(messages chan *messager.VersionMessag
 	}()
 
 	m.Called(messages, cliVersion)
+	return messages
 }
 
 func (m *mockMessager) HandleVersionMessage(messageChannel <-chan *messager.VersionMessage) {
@@ -65,7 +67,7 @@ func (lc *LocalConfigMock) Set(key string, value string) error {
 
 func TestSetCommand(t *testing.T) {
 	messager := &mockMessager{}
-	messager.On("LoadVersionMessages", mock.Anything, mock.Anything)
+	messager.On("LoadVersionMessages", mock.Anything)
 
 	printerMock := &PrinterMock{}
 	printerMock.On("PrintWarnings", mock.Anything)

--- a/cmd/publish/main.go
+++ b/cmd/publish/main.go
@@ -58,11 +58,9 @@ func New(ctx *PublishCommandContext) *cobra.Command {
 			if (outputFlag != "json") && (outputFlag != "yaml") && (outputFlag != "xml") {
 
 				messages := ctx.Messager.LoadVersionMessages(ctx.CliVersion)
-				defer func() {
-					for msg := range messages {
-						ctx.Printer.PrintMessage(msg.MessageText+"\n", msg.MessageColor)
-					}
-				}()
+				for msg := range messages {
+					ctx.Printer.PrintMessage(msg.MessageText+"\n", msg.MessageColor)
+				}
 			}
 			return nil
 		},

--- a/cmd/publish/main.go
+++ b/cmd/publish/main.go
@@ -53,9 +53,7 @@ func New(ctx *PublishCommandContext) *cobra.Command {
 			}
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			messages := make(chan *messager.VersionMessage, 1)
 			go ctx.Messager.LoadVersionMessages(messages, ctx.CliVersion)
 			defer func() {
@@ -64,6 +62,11 @@ func New(ctx *PublishCommandContext) *cobra.Command {
 					ctx.Printer.PrintMessage(msg.MessageText+"\n", msg.MessageColor)
 				}
 			}()
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
 
 			publishFailedResponse, err := publish(ctx, args[0])
 			if publishFailedResponse != nil {

--- a/cmd/publish/main_test.go
+++ b/cmd/publish/main_test.go
@@ -26,7 +26,8 @@ type MessagerMock struct {
 	mock.Mock
 }
 
-func (m *MessagerMock) LoadVersionMessages(messages chan *messager.VersionMessage, cliVersion string) {
+func (m *MessagerMock) LoadVersionMessages(cliVersion string) chan *messager.VersionMessage {
+	messages := make(chan *messager.VersionMessage, 1)
 	go func() {
 		messages <- &messager.VersionMessage{
 			CliVersion:   "1.2.3",
@@ -36,6 +37,7 @@ func (m *MessagerMock) LoadVersionMessages(messages chan *messager.VersionMessag
 	}()
 
 	m.Called(messages, cliVersion)
+	return messages
 }
 
 type PrinterMock struct {
@@ -60,7 +62,7 @@ func TestPublishCommand(t *testing.T) {
 	localConfigMock.On("GetLocalConfiguration")
 
 	messagerMock := &MessagerMock{}
-	messagerMock.On("LoadVersionMessages", mock.Anything, mock.Anything)
+	messagerMock.On("LoadVersionMessages", mock.Anything)
 
 	printerMock := &PrinterMock{}
 	printerMock.On("PrintMessage", mock.Anything, mock.Anything)

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -139,11 +139,9 @@ func New(ctx *TestCommandContext) *cobra.Command {
 			if (outputFlag != "json") && (outputFlag != "yaml") && (outputFlag != "xml") {
 
 				messages := ctx.Messager.LoadVersionMessages(ctx.CliVersion)
-				defer func() {
-					for msg := range messages {
-						ctx.Printer.PrintMessage(msg.MessageText+"\n", msg.MessageColor)
-					}
-				}()
+				for msg := range messages {
+					ctx.Printer.PrintMessage(msg.MessageText+"\n", msg.MessageColor)
+				}
 			}
 			return nil
 		},

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -32,7 +32,7 @@ type Evaluator interface {
 }
 
 type Messager interface {
-	LoadVersionMessages(messages chan *messager.VersionMessage, cliVersion string)
+	LoadVersionMessages(cliVersion string) chan *messager.VersionMessage
 }
 
 type K8sValidator interface {
@@ -135,14 +135,16 @@ func New(ctx *TestCommandContext) *cobra.Command {
 			return nil
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			messages := make(chan *messager.VersionMessage, 1)
-			go ctx.Messager.LoadVersionMessages(messages, ctx.CliVersion)
-			defer func() {
-				msg, ok := <-messages
-				if ok {
-					ctx.Printer.PrintMessage(msg.MessageText+"\n", msg.MessageColor)
-				}
-			}()
+			outputFlag, _ := cmd.Flags().GetString("output")
+			if (outputFlag != "json") && (outputFlag != "yaml") && (outputFlag != "xml") {
+
+				messages := ctx.Messager.LoadVersionMessages(ctx.CliVersion)
+				defer func() {
+					for msg := range messages {
+						ctx.Printer.PrintMessage(msg.MessageText+"\n", msg.MessageColor)
+					}
+				}()
+			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/test/main_test.go
+++ b/cmd/test/main_test.go
@@ -43,7 +43,8 @@ type mockMessager struct {
 	mock.Mock
 }
 
-func (m *mockMessager) LoadVersionMessages(messages chan *messager.VersionMessage, cliVersion string) {
+func (m *mockMessager) LoadVersionMessages(cliVersion string) chan *messager.VersionMessage {
+	messages := make(chan *messager.VersionMessage, 1)
 	go func() {
 		messages <- &messager.VersionMessage{
 			CliVersion:   "1.2.3",
@@ -52,7 +53,8 @@ func (m *mockMessager) LoadVersionMessages(messages chan *messager.VersionMessag
 		close(messages)
 	}()
 
-	m.Called(messages, cliVersion)
+	m.Called(cliVersion)
+	return messages
 }
 
 func (m *mockMessager) HandleVersionMessage(messageChannel <-chan *messager.VersionMessage) {
@@ -141,7 +143,7 @@ func TestTestCommand(t *testing.T) {
 	mockedEvaluator.On("UpdateFailedYamlValidation", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mockedEvaluator.On("UpdateFailedK8sValidation", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	messager := &mockMessager{}
-	messager.On("LoadVersionMessages", mock.Anything, mock.Anything)
+	messager.On("LoadVersionMessages", mock.Anything)
 
 	k8sValidatorMock := &K8sValidatorMock{}
 

--- a/cmd/version/main.go
+++ b/cmd/version/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Messager interface {
-	LoadVersionMessages(messages chan *messager.VersionMessage, cliVersion string)
+	LoadVersionMessages(cliVersion string) chan *messager.VersionMessage
 }
 
 type Printer interface {
@@ -21,8 +21,7 @@ type VersionCommandContext struct {
 }
 
 func version(ctx *VersionCommandContext) {
-	messages := make(chan *messager.VersionMessage, 1)
-	go ctx.Messager.LoadVersionMessages(messages, ctx.CliVersion)
+	messages := ctx.Messager.LoadVersionMessages(ctx.CliVersion)
 	fmt.Println(ctx.CliVersion)
 	msg, ok := <-messages
 	if ok {

--- a/cmd/version/main_test.go
+++ b/cmd/version/main_test.go
@@ -21,7 +21,8 @@ func (p *printerMock) PrintMessage(messageText string, messageColor string) {
 	p.Called(messageText, messageColor)
 }
 
-func (m *mockMessager) LoadVersionMessages(messages chan *messager.VersionMessage, cliVersion string) {
+func (m *mockMessager) LoadVersionMessages(cliVersion string) chan *messager.VersionMessage {
+	messages := make(chan *messager.VersionMessage, 1)
 	go func() {
 		messages <- &messager.VersionMessage{
 			CliVersion:   "0.0.1",
@@ -32,12 +33,13 @@ func (m *mockMessager) LoadVersionMessages(messages chan *messager.VersionMessag
 		close(messages)
 	}()
 
-	m.Called(messages, cliVersion)
+	m.Called(cliVersion)
+	return messages
 }
 
 func Test_ExecuteCommand(t *testing.T) {
 	messager := &mockMessager{}
-	messager.On("LoadVersionMessages", mock.Anything, mock.Anything).Return(nil)
+	messager.On("LoadVersionMessages", mock.Anything).Return(nil)
 
 	printer := &printerMock{}
 	printer.On("PrintMessage", mock.Anything, mock.Anything).Return(nil)


### PR DESCRIPTION
Fixes: #386

**Description**
Run `LoadVersionMessages` as a part of PreRunE hook

**Type of changes**
Refactor/Enhancements