### PR TITLE
refactor: move argument logic to `Args` block

### DIFF
--- a/cmd/kustomize/main.go
+++ b/cmd/kustomize/main.go
@@ -1,6 +1,7 @@
 package kustomize
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -43,6 +44,14 @@ func New(testCtx *test.TestCommandContext, kustomizeCtx *KustomizeContext) *cobr
 		# Test the kustomize build from github
 		datree kustomize test https://github.com/kubernetes-sigs/kustomize.git/examples/helloWorld?ref=v1.0.6
 		`),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if args[0] == "-" {
+				if len(args) > 1 {
+					return fmt.Errorf(fmt.Sprintf("Unexpected args: [%s]", strings.Join(args[1:], ",")))
+				}
+			}
+			return nil
+		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return test.LoadVersionMessages(testCtx, args, cmd)
 		},

--- a/cmd/kustomize/main.go
+++ b/cmd/kustomize/main.go
@@ -1,7 +1,6 @@
 package kustomize
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -45,11 +44,7 @@ func New(testCtx *test.TestCommandContext, kustomizeCtx *KustomizeContext) *cobr
 		datree kustomize test https://github.com/kubernetes-sigs/kustomize.git/examples/helloWorld?ref=v1.0.6
 		`),
 		Args: func(cmd *cobra.Command, args []string) error {
-			if args[0] == "-" {
-				if len(args) > 1 {
-					return fmt.Errorf(fmt.Sprintf("Unexpected args: [%s]", strings.Join(args[1:], ",")))
-				}
-			}
+			utils.ValidateStdinPathArgument(args)
 			return nil
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/kustomize/main.go
+++ b/cmd/kustomize/main.go
@@ -44,8 +44,7 @@ func New(testCtx *test.TestCommandContext, kustomizeCtx *KustomizeContext) *cobr
 		datree kustomize test https://github.com/kubernetes-sigs/kustomize.git/examples/helloWorld?ref=v1.0.6
 		`),
 		Args: func(cmd *cobra.Command, args []string) error {
-			utils.ValidateStdinPathArgument(args)
-			return nil
+			return utils.ValidateStdinPathArgument(args)
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return test.LoadVersionMessages(testCtx, args, cmd)

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -170,12 +170,12 @@ func New(ctx *TestCommandContext) *cobra.Command {
 			if len(args) < 1 {
 				errMessage := "Requires at least 1 arg\n"
 				return fmt.Errorf(errMessage)
+			} else if args[0] == "-" {
+				if len(args) > 1 {
+					return fmt.Errorf(fmt.Sprintf("Unexpected args: [%s]", strings.Join(args[1:], ",")))
+				}
 			}
-			err := testCommandFlags.Validate()
-			if err != nil {
-				return err
-			}
-			return nil
+			return testCommandFlags.Validate()
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return LoadVersionMessages(ctx, args, cmd)
@@ -188,11 +188,6 @@ func New(ctx *TestCommandContext) *cobra.Command {
 					ctx.Printer.PrintMessage(strings.Join([]string{"\n", err.Error(), "\n"}, ""), "error")
 				}
 			}()
-
-			err = testCommandFlags.Validate()
-			if err != nil {
-				return err
-			}
 
 			localConfigContent, err := ctx.LocalConfig.GetLocalConfiguration()
 			if err != nil {
@@ -301,9 +296,6 @@ func validateK8sVersionFormatIfProvided(k8sVersion string) error {
 
 func Test(ctx *TestCommandContext, paths []string, prerunData *TestCommandData) error {
 	if paths[0] == "-" {
-		if len(paths) > 1 {
-			return fmt.Errorf(fmt.Sprintf("Unexpected args: [%s]", strings.Join(paths[1:], ",")))
-		}
 		tempFile, err := os.CreateTemp("", "datree_temp_*.yaml")
 		if err != nil {
 			return err

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -170,11 +170,8 @@ func New(ctx *TestCommandContext) *cobra.Command {
 			if len(args) < 1 {
 				errMessage := "Requires at least 1 arg\n"
 				return fmt.Errorf(errMessage)
-			} else if args[0] == "-" {
-				if len(args) > 1 {
-					return fmt.Errorf(fmt.Sprintf("Unexpected args: [%s]", strings.Join(args[1:], ",")))
-				}
 			}
+			utils.ValidateStdinPathArgument(args)
 			return testCommandFlags.Validate()
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -171,7 +171,10 @@ func New(ctx *TestCommandContext) *cobra.Command {
 				errMessage := "Requires at least 1 arg\n"
 				return fmt.Errorf(errMessage)
 			}
-			utils.ValidateStdinPathArgument(args)
+			err := utils.ValidateStdinPathArgument(args)
+			if err != nil {
+				return err
+			}
 			return testCommandFlags.Validate()
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,6 +1,9 @@
 package utils
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 func Example(s string) string {
 	if len(s) == 0 {
@@ -29,4 +32,14 @@ func (s normalize) indent() normalize {
 	}
 	s.string = strings.Join(indentedLines, "\n")
 	return s
+}
+
+func ValidateStdinPathArgument(paths []string) error {
+	if paths[0] == "-" {
+		if len(paths) > 1 {
+			return fmt.Errorf(fmt.Sprintf("Unexpected args: [%s]", strings.Join(paths[1:], ",")))
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Fixes: #433 

**Changes proposed in the PR**
In this PR we need to move arguments validation logic in the `Args` block of cobra command. 

**Testing Instruction**
Since this is a refactor work make sure all test cases are passing, build is successful and functionality is working as expected.
