### PR TITLE
feat: add 'how to fix' link

### DIFF
--- a/bl/evaluation/evaluator.go
+++ b/bl/evaluation/evaluator.go
@@ -216,6 +216,7 @@ func (e *Evaluator) formatEvaluationResults(evaluationResults FailedRulesByFiles
 				mapper[filePath][ruleIdentifier] = &Rule{
 					Identifier:         ruleIdentifier,
 					Name:               failedRuleData.Name,
+					DocumentationUrl:   failedRuleData.DocumentationUrl,
 					MessageOnFailure:   failedRuleData.MessageOnFailure,
 					OccurrencesDetails: []OccurrenceDetails{},
 				}
@@ -266,10 +267,10 @@ func calculateFailedRulesByFiles(currentFailedRulesByFiles FailedRulesByFiles, v
 				ruleData.Configurations = append(ruleData.Configurations, configurationData)
 				currentFailedRulesByFiles[fileName][rule.RuleIdentifier] = ruleData
 			} else {
-				currentFailedRulesByFiles[fileName][rule.RuleIdentifier] = cliClient.FailedRule{Name: rule.RuleName, MessageOnFailure: rule.MessageOnFailure, Configurations: []cliClient.Configuration{configurationData}}
+				currentFailedRulesByFiles[fileName][rule.RuleIdentifier] = cliClient.FailedRule{Name: rule.RuleName, DocumentationUrl: rule.DocumentationUrl, MessageOnFailure: rule.MessageOnFailure, Configurations: []cliClient.Configuration{configurationData}}
 			}
 		} else {
-			currentFailedRulesByFiles[fileName] = map[string]cliClient.FailedRule{rule.RuleIdentifier: {Name: rule.RuleName, MessageOnFailure: rule.MessageOnFailure, Configurations: []cliClient.Configuration{configurationData}}}
+			currentFailedRulesByFiles[fileName] = map[string]cliClient.FailedRule{rule.RuleIdentifier: {Name: rule.RuleName, DocumentationUrl: rule.DocumentationUrl, MessageOnFailure: rule.MessageOnFailure, Configurations: []cliClient.Configuration{configurationData}}}
 		}
 	}
 

--- a/bl/evaluation/printer.go
+++ b/bl/evaluation/printer.go
@@ -170,13 +170,13 @@ func parseToPrinterWarnings(results *EvaluationResults, invalidYamlFiles []*extr
 
 			for _, ruleUniqueName := range rulesUniqueNames {
 				rule := rules[ruleUniqueName]
-				var fixLink string = ""
+				var fixLink string
 				if verbose {
 					fixLink = rule.DocumentationUrl
 				}
 				failedRule := printer.FailedRule{
 					Name:               rule.Name,
-					HowToFix:           fixLink,
+					DocumentationUrl:   fixLink,
 					Occurrences:        rule.GetOccurrencesCount(),
 					Suggestion:         rule.MessageOnFailure,
 					OccurrencesDetails: []printer.OccurrenceDetails{},

--- a/bl/evaluation/printer.go
+++ b/bl/evaluation/printer.go
@@ -9,8 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	internal_policy "github.com/datreeio/datree/pkg/policy"
-
 	"github.com/datreeio/datree/pkg/extractor"
 
 	"github.com/datreeio/datree/pkg/printer"
@@ -170,18 +168,12 @@ func parseToPrinterWarnings(results *EvaluationResults, invalidYamlFiles []*extr
 				rulesUniqueNames = append(rulesUniqueNames, rulesUniqueName)
 			}
 
-			defaultRules, _ := internal_policy.GetDefaultRules()
-
 			for _, ruleUniqueName := range rulesUniqueNames {
+				rule := rules[ruleUniqueName]
 				var fixLink string = ""
 				if verbose {
-					for _, deaultRule := range defaultRules.Rules {
-						if deaultRule.UniqueName == ruleUniqueName {
-							fixLink = deaultRule.DocumentationUrl
-						}
-					}
+					fixLink = rule.DocumentationUrl
 				}
-				rule := rules[ruleUniqueName]
 				failedRule := printer.FailedRule{
 					Name:               rule.Name,
 					HowToFix:           fixLink,

--- a/bl/evaluation/printer_test.go
+++ b/bl/evaluation/printer_test.go
@@ -66,7 +66,7 @@ func TestPrintResults(t *testing.T) {
 		mockedPrinter.On("PrintEvaluationSummary", mock.Anything, mock.Anything)
 
 		t.Run(tt.name, func(t *testing.T) {
-			_ = PrintResults(tt.args.results, tt.args.invalidYamlFiles, tt.args.invalidK8sFiles, tt.args.evaluationSummary, tt.args.loginURL, tt.args.outputFormat, mockedPrinter, "1.18.0", "Default")
+			_ = PrintResults(tt.args.results, tt.args.invalidYamlFiles, tt.args.invalidK8sFiles, tt.args.evaluationSummary, tt.args.loginURL, tt.args.outputFormat, mockedPrinter, "1.18.0", "Default", false)
 
 			if tt.args.outputFormat == "json" {
 				mockedPrinter.AssertNotCalled(t, "PrintWarnings")
@@ -76,7 +76,7 @@ func TestPrintResults(t *testing.T) {
 				mockedPrinter.AssertNotCalled(t, "PrintWarnings")
 			} else {
 				pwd, _ := os.Getwd()
-				warnings, _ := parseToPrinterWarnings(tt.args.results.EvaluationResults, tt.args.invalidYamlFiles, tt.args.invalidK8sFiles, pwd, "1.18.0")
+				warnings, _ := parseToPrinterWarnings(tt.args.results.EvaluationResults, tt.args.invalidYamlFiles, tt.args.invalidK8sFiles, pwd, "1.18.0", false)
 				mockedPrinter.AssertCalled(t, "PrintWarnings", warnings)
 			}
 		})

--- a/bl/evaluation/rule.go
+++ b/bl/evaluation/rule.go
@@ -4,6 +4,7 @@ type Rule struct {
 	Identifier         string
 	Name               string
 	MessageOnFailure   string
+	DocumentationUrl   string
 	OccurrencesDetails []OccurrenceDetails
 }
 

--- a/bl/policy/policy_factory.go
+++ b/bl/policy/policy_factory.go
@@ -16,6 +16,7 @@ type Policy struct {
 type RuleWithSchema struct {
 	RuleIdentifier   string
 	RuleName         string
+	DocumentationUrl string
 	Schema           map[string]interface{}
 	MessageOnFailure string
 }
@@ -72,12 +73,12 @@ func populateRules(policyRules []cliClient.Rule, customRules []*cliClient.Custom
 		customRule := getCustomRuleByIdentifier(customRules, rule.Identifier)
 
 		if customRule != nil {
-			rules = append(rules, RuleWithSchema{rule.Identifier, customRule.Name, customRule.Schema, rule.MessageOnFailure})
+			rules = append(rules, RuleWithSchema{rule.Identifier, customRule.Name, "", customRule.Schema, rule.MessageOnFailure})
 		} else {
 			defaultRule := getDefaultRuleByIdentifier(defaultRules, rule.Identifier)
 
 			if defaultRule != nil {
-				rules = append(rules, RuleWithSchema{rule.Identifier, defaultRule.Name, defaultRule.Schema, rule.MessageOnFailure})
+				rules = append(rules, RuleWithSchema{rule.Identifier, defaultRule.Name, defaultRule.DocumentationUrl, defaultRule.Schema, rule.MessageOnFailure})
 			} else {
 				rulesIsNotCustomNorDefaultErr := fmt.Errorf("rule %s is not custom nor default", rule.Identifier)
 				return nil, rulesIsNotCustomNorDefaultErr
@@ -113,7 +114,7 @@ func createDefaultPolicy(defaultRules *internal_policy.DefaultRulesDefinitions) 
 
 	for _, defaultRule := range defaultRules.Rules {
 		if defaultRule.EnabledByDefault {
-			rules = append(rules, RuleWithSchema{defaultRule.UniqueName, defaultRule.Name, defaultRule.Schema, defaultRule.MessageOnFailure})
+			rules = append(rules, RuleWithSchema{defaultRule.UniqueName, defaultRule.Name, defaultRule.DocumentationUrl, defaultRule.Schema, defaultRule.MessageOnFailure})
 		}
 	}
 

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -46,6 +46,7 @@ type TestCommandFlags struct {
 	K8sVersion           string
 	IgnoreMissingSchemas bool
 	OnlyK8sFiles         bool
+	Verbose              bool
 	PolicyName           string
 	SchemaLocations      []string
 	PolicyConfig         string
@@ -58,6 +59,7 @@ func NewTestCommandFlags() *TestCommandFlags {
 		K8sVersion:           "",
 		IgnoreMissingSchemas: false,
 		OnlyK8sFiles:         false,
+		Verbose:              false,
 		PolicyName:           "",
 		SchemaLocations:      make([]string, 0),
 	}
@@ -114,6 +116,7 @@ type TestCommandData struct {
 	K8sVersion            string
 	IgnoreMissingSchemas  bool
 	OnlyK8sFiles          bool
+	Verbose               bool
 	Policy                policy_factory.Policy
 	SchemaLocations       []string
 	Token                 string
@@ -228,7 +231,7 @@ func (flags *TestCommandFlags) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&flags.PolicyConfig, "policy-config", "", "Policy name to run against")
 	cmd.Flags().BoolVar(&flags.OnlyK8sFiles, "only-k8s-files", false, "Evaluate only valid yaml files with the properties 'apiVersion' and 'kind'. Ignore everything else")
-
+	cmd.Flags().BoolVar(&flags.Verbose, "verbose", false, "enables or disables 'How to Fix' link")
 	// kubeconform flag
 	cmd.Flags().StringArrayVarP(&flags.SchemaLocations, "schema-location", "", []string{}, "Override schemas location search path (can be specified multiple times)")
 	cmd.Flags().BoolVarP(&flags.IgnoreMissingSchemas, "ignore-missing-schemas", "", false, "Ignore missing schemas when executing schema validation step")
@@ -268,6 +271,7 @@ func GenerateTestCommandData(testCommandFlags *TestCommandFlags, localConfigCont
 		K8sVersion:            k8sVersion,
 		IgnoreMissingSchemas:  testCommandFlags.IgnoreMissingSchemas,
 		OnlyK8sFiles:          testCommandFlags.OnlyK8sFiles,
+		Verbose:               testCommandFlags.Verbose,
 		Policy:                policy,
 		SchemaLocations:       testCommandFlags.SchemaLocations,
 		Token:                 localConfigContent.Token,
@@ -346,7 +350,7 @@ func Test(ctx *TestCommandContext, paths []string, prerunData *TestCommandData) 
 		PassedPolicyCheckCount:    passedPolicyCheckCount,
 	}
 
-	err = evaluation.PrintResults(results, validationManager.InvalidYamlFiles(), validationManager.InvalidK8sFiles(), evaluationSummary, prerunData.RegistrationURL, prerunData.Output, ctx.Printer, prerunData.K8sVersion, prerunData.Policy.Name)
+	err = evaluation.PrintResults(results, validationManager.InvalidYamlFiles(), validationManager.InvalidK8sFiles(), evaluationSummary, prerunData.RegistrationURL, prerunData.Output, ctx.Printer, prerunData.K8sVersion, prerunData.Policy.Name, prerunData.Verbose)
 
 	if evaluationResultData.PromptMessage != "" {
 		ctx.Printer.PrintPromptMessage(evaluationResultData.PromptMessage)

--- a/pkg/cliClient/evaluation.go
+++ b/pkg/cliClient/evaluation.go
@@ -134,6 +134,7 @@ type Configuration struct {
 
 type FailedRule struct {
 	Name             string          `json:"ruleName"`
+	DocumentationUrl string          `json:"documentationUrl"`
 	MessageOnFailure string          `json:"messageOnFailure"`
 	Configurations   []Configuration `json:"configurations"`
 }

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -150,7 +150,7 @@ func (p *Printer) PrintWarnings(warnings []Warning) {
 				fmt.Fprintf(out, "%v %v %v\n", p.Theme.Emoji.Error, ruleName, occurrences)
 
 				if failedRule.HowToFix != "" {
-					howToFix := p.Theme.Colors.Yellow.Sprint(failedRule.HowToFix)
+					howToFix := p.Theme.Colors.Cyan.Sprint(failedRule.HowToFix)
 					fmt.Fprintf(out, "    How to fix: %v\n", howToFix)
 				}
 

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -27,7 +27,7 @@ type FailedRule struct {
 	Name               string
 	Occurrences        int
 	Suggestion         string
-	HowToFix           string
+	DocumentationUrl   string
 	OccurrencesDetails []OccurrenceDetails
 }
 

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -149,8 +149,8 @@ func (p *Printer) PrintWarnings(warnings []Warning) {
 
 				fmt.Fprintf(out, "%v %v %v\n", p.Theme.Emoji.Error, ruleName, occurrences)
 
-				if failedRule.HowToFix != "" {
-					howToFix := p.Theme.Colors.Cyan.Sprint(failedRule.HowToFix)
+				if failedRule.DocumentationUrl != "" {
+					howToFix := p.Theme.Colors.Cyan.Sprint(failedRule.DocumentationUrl)
 					fmt.Fprintf(out, "    How to fix: %v\n", howToFix)
 				}
 

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -27,6 +27,7 @@ type FailedRule struct {
 	Name               string
 	Occurrences        int
 	Suggestion         string
+	HowToFix           string
 	OccurrencesDetails []OccurrenceDetails
 }
 
@@ -147,6 +148,12 @@ func (p *Printer) PrintWarnings(warnings []Warning) {
 				ruleName := p.Theme.Colors.RedBold.Sprint(failedRule.Name)
 
 				fmt.Fprintf(out, "%v %v %v\n", p.Theme.Emoji.Error, ruleName, occurrences)
+
+				if failedRule.HowToFix != "" {
+					howToFix := p.Theme.Colors.Yellow.Sprint(failedRule.HowToFix)
+					fmt.Fprintf(out, "    How to fix: %v\n", howToFix)
+				}
+
 				for _, occurrenceDetails := range failedRule.OccurrencesDetails {
 					fmt.Fprintf(out, "    — metadata.name: %v (kind: %v)\n", p.getStringOrNotAvailable(occurrenceDetails.MetadataName), p.getStringOrNotAvailable(occurrenceDetails.Kind))
 				}


### PR DESCRIPTION
feat #446 

code changes:
- Introduced a verbose flag as suggested by @noaabarki for test command
- mapped each failed rule to its "how to fix" link in `parseToPrinterWarnings` method in "/bl/evaluation/printer.go" file
- made changes in within `PrintWarnings` method in "/pkg/printer/printer.go" to print how-to-fix links to the console

Below are the screenshots with the feature implemented

![Screenshot 2022-03-21 at 8 52 06 PM](https://user-images.githubusercontent.com/35053650/159386183-8dd7c64c-4769-468f-912b-8cba12c72a74.png)
![Screenshot 2022-03-21 at 8 52 39 PM](https://user-images.githubusercontent.com/35053650/159386226-6d31adbb-c473-486a-840f-df7ac11c4db4.png)