### PR TITLE
fix: evaluations fail when metadata key is missing

### DIFF
--- a/bl/evaluation/evaluator.go
+++ b/bl/evaluation/evaluator.go
@@ -247,15 +247,20 @@ func (e *Evaluator) formatEvaluationResults(evaluationResults FailedRulesByFiles
 }
 
 func extractConfigurationInfo(configuration extractor.Configuration) (string, string) {
-	kind := configuration["kind"].(string)
-	metadata := configuration["metadata"]
+	kind := ""
+	name := ""
 
-	nonStringName := metadata.(map[string]interface{})["name"]
-	var name string
-	if nonStringName != nil {
-		name = nonStringName.(string)
-	} else {
-		name = ""
+	nonStringKind := configuration["kind"]
+	if nonStringKind != nil {
+		kind = nonStringKind.(string)
+	}
+
+	nonObjectMetadata := configuration["metadata"]
+	if nonObjectMetadata != nil {
+		nonStringName := nonObjectMetadata.(map[string]interface{})["name"]
+		if nonStringName != nil {
+			name = nonStringName.(string)
+		}
 	}
 
 	return name, kind

--- a/internal/fixtures/kube/Rollout.yaml
+++ b/internal/fixtures/kube/Rollout.yaml
@@ -1,0 +1,24 @@
+# Rollout doesn't require the metadata key,
+# should fail gracefully for rule 38 ARGO_ROLLOUT_MISSING_PAUSE_DURATION
+# and display metadata.name: N/A
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+spec:
+  strategy:
+    canary:
+      analysis:
+        templates:
+          - templateName: success-rate
+        startingStep: 2 # delay starting analysis run until setWeight: 40%
+        args:
+          - name: service-name
+            value: guestbook-svc.default.svc.cluster.local
+      steps:
+        - setWeight: 20
+        - pause: {duration: 10m}
+        - setWeight: 40
+        - pause: {duration: 10m}
+        - setWeight: 60
+        - pause: {duration: 10m}
+        - setWeight: 80
+        - pause: { }


### PR DESCRIPTION
after the fix, running Rollout.yaml with rule 38 enabled

<img width="843" alt="Screen Shot 2022-03-30 at 4 31 59" src="https://user-images.githubusercontent.com/39004075/160732967-9c1f8ccb-0ae1-4530-8489-9e2592a495a5.png">
