### PR TITLE
fix: exclude defaultSchemaLocations in offline k8s validation

### DIFF
--- a/bl/validation/k8sValidator.go
+++ b/bl/validation/k8sValidator.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"fmt"
 	"github.com/datreeio/datree/pkg/extractor"
+	"github.com/datreeio/datree/pkg/utils"
 	kubeconformValidator "github.com/yannh/kubeconform/pkg/validator"
 	"io"
 	"net/http"
@@ -178,13 +179,14 @@ func (val *K8sValidator) validateResource(filepath string) (bool, []error, *vali
 		}
 		if res.Status == kubeconformValidator.Invalid || res.Status == kubeconformValidator.Error {
 			isValid = false
+			errString := res.Err.Error()
 
-			errorMessages := strings.Split(res.Err.Error(), "-")
-
-			if len(errorMessages) > 0 {
+			if utils.IsNetworkError(errString) {
+				validationErrors = append(validationErrors, &InvalidK8sSchemaError{errString})
+			} else {
+				errorMessages := strings.Split(errString, "-")
 				for _, errorMessage := range errorMessages {
-					msg := strings.Trim(errorMessage, " ")
-					validationErrors = append(validationErrors, &InvalidK8sSchemaError{ErrorMessage: msg})
+					validationErrors = append(validationErrors, &InvalidK8sSchemaError{ErrorMessage: strings.Trim(errorMessage, " ")})
 				}
 			}
 		}

--- a/bl/validation/k8sValidator.go
+++ b/bl/validation/k8sValidator.go
@@ -30,12 +30,12 @@ func New() *K8sValidator {
 }
 
 func (val *K8sValidator) InitClient(k8sVersion string, ignoreMissingSchemas bool, userProvidedSchemaLocations []string) {
-	val.isOffline = val.checkIsOffline()
+	val.isOffline = checkIsOffline()
 	val.areThereCustomSchemaLocations = len(userProvidedSchemaLocations) > 0
 	val.validationClient = newKubeconformValidator(k8sVersion, ignoreMissingSchemas, getAllSchemaLocations(userProvidedSchemaLocations, val.isOffline))
 }
 
-func (val *K8sValidator) checkIsOffline() bool {
+func checkIsOffline() bool {
 	client := http.Client{
 		Timeout: 10 * time.Second,
 	}

--- a/bl/validation/k8sValidator.go
+++ b/bl/validation/k8sValidator.go
@@ -156,10 +156,6 @@ func (val *K8sValidator) validateResource(filepath string) (bool, []error, *vali
 
 	defer f.Close()
 
-	if val.isOffline && !val.areThereCustomSchemaLocations {
-		return true, []error{}, noConnectionWarning, nil
-	}
-
 	results := val.validationClient.Validate(filepath, f)
 
 	// Return an error if no valid configurations found

--- a/bl/validation/k8sValidator.go
+++ b/bl/validation/k8sValidator.go
@@ -12,6 +12,11 @@ import (
 	"time"
 )
 
+var noConnectionWarning = &validationWarning{
+	WarningKind:    NetworkError,
+	WarningMessage: "k8s schema validation skipped: no internet connection",
+}
+
 type ValidationClient interface {
 	Validate(filename string, r io.ReadCloser) []kubeconformValidator.Result
 }
@@ -152,10 +157,6 @@ func (val *K8sValidator) validateResource(filepath string) (bool, []error, *vali
 	defer f.Close()
 
 	if val.isOffline && !val.areThereCustomSchemaLocations {
-		noConnectionWarning := &validationWarning{
-			WarningKind:    NetworkError,
-			WarningMessage: "k8s schema validation skipped: no internet connection",
-		}
 		return true, []error{}, noConnectionWarning, nil
 	}
 
@@ -178,10 +179,6 @@ func (val *K8sValidator) validateResource(filepath string) (bool, []error, *vali
 		}
 		if res.Status == kubeconformValidator.Invalid || res.Status == kubeconformValidator.Error {
 			if utils.IsNetworkError(res.Err.Error()) {
-				noConnectionWarning := &validationWarning{
-					WarningKind:    NetworkError,
-					WarningMessage: "k8s schema validation skipped: no internet connection",
-				}
 				return true, []error{}, noConnectionWarning, nil
 			}
 			isValid = false

--- a/bl/validation/k8sValidator.go
+++ b/bl/validation/k8sValidator.go
@@ -2,13 +2,13 @@ package validation
 
 import (
 	"fmt"
+	"github.com/datreeio/datree/pkg/extractor"
+	kubeconformValidator "github.com/yannh/kubeconform/pkg/validator"
 	"io"
+	"net/http"
 	"os"
 	"strings"
-
-	"github.com/datreeio/datree/pkg/extractor"
-	"github.com/datreeio/datree/pkg/utils"
-	kubeconformValidator "github.com/yannh/kubeconform/pkg/validator"
+	"time"
 )
 
 type ValidationClient interface {
@@ -17,6 +17,7 @@ type ValidationClient interface {
 
 type K8sValidator struct {
 	validationClient              ValidationClient
+	isOffline                     bool
 	areThereCustomSchemaLocations bool
 }
 
@@ -26,9 +27,23 @@ func New() *K8sValidator {
 	return &K8sValidator{}
 }
 
-func (val *K8sValidator) InitClient(k8sVersion string, ignoreMissingSchemas bool, schemaLocations []string) {
-	val.areThereCustomSchemaLocations = len(schemaLocations) > 0
-	val.validationClient = newKubeconformValidator(k8sVersion, ignoreMissingSchemas, getAllSchemaLocations(schemaLocations))
+func (val *K8sValidator) InitClient(k8sVersion string, ignoreMissingSchemas bool, userProvidedSchemaLocations []string) {
+	val.isOffline = val.checkIsOffline()
+	val.areThereCustomSchemaLocations = len(userProvidedSchemaLocations) > 0
+	val.validationClient = newKubeconformValidator(k8sVersion, ignoreMissingSchemas, getAllSchemaLocations(userProvidedSchemaLocations, val.isOffline))
+}
+
+// TODO move to DI for tests
+func (val *K8sValidator) checkIsOffline() bool {
+	client := http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get("https://www.githubstatus.com/api/v2/status.json")
+	if err == nil && resp != nil && resp.StatusCode == 200 {
+		return false
+	} else {
+		return true
+	}
 }
 
 type WarningKind int
@@ -136,6 +151,14 @@ func (val *K8sValidator) validateResource(filepath string) (bool, []error, *vali
 
 	defer f.Close()
 
+	if val.isOffline && !val.areThereCustomSchemaLocations {
+		noConnectionWarning := &validationWarning{
+			WarningKind:    NetworkError,
+			WarningMessage: "k8s schema validation skipped: no internet connection",
+		}
+		return true, []error{}, noConnectionWarning, nil
+	}
+
 	results := val.validationClient.Validate(filepath, f)
 
 	// Return an error if no valid configurations found
@@ -154,18 +177,9 @@ func (val *K8sValidator) validateResource(filepath string) (bool, []error, *vali
 			isAtLeastOneConfigSkipped = true
 		}
 		if res.Status == kubeconformValidator.Invalid || res.Status == kubeconformValidator.Error {
-			if utils.IsNetworkError(res.Err.Error()) && !val.areThereCustomSchemaLocations {
-				noConnectionWarning := &validationWarning{
-					WarningKind:    NetworkError,
-					WarningMessage: "k8s schema validation skipped: no internet connection",
-				}
-				return true, []error{}, noConnectionWarning, nil
-			}
 			isValid = false
-
 			errorMessages := strings.Split(res.Err.Error(), "-")
 
-			// errorMessages slice is not empty
 			if len(errorMessages) > 0 {
 				for _, errorMessage := range errorMessages {
 					msg := strings.Trim(errorMessage, " ")
@@ -199,11 +213,13 @@ func isEveryResultStatusEmpty(results []kubeconformValidator.Result) bool {
 	return isEveryResultStatusEmpty
 }
 
-func getAllSchemaLocations(userProvidedSchemaLocations []string) []string {
-	// order matters!
-	// it's important that provided schema locations (from --schema-locations flag) are *before* the default schema locations
-	// this will give them priority and allow using a local schema in offline mode
-	return append(userProvidedSchemaLocations, getDefaultSchemaLocations()...)
+func getAllSchemaLocations(userProvidedSchemaLocations []string, isOffline bool) []string {
+	if isOffline {
+		return userProvidedSchemaLocations
+	} else {
+		// order matters! userProvidedSchemaLocations get priority over defaultSchemaLocations
+		return append(userProvidedSchemaLocations, getDefaultSchemaLocations()...)
+	}
 }
 
 func getDefaultSchemaLocations() []string {

--- a/bl/validation/k8sValidator.go
+++ b/bl/validation/k8sValidator.go
@@ -3,7 +3,6 @@ package validation
 import (
 	"fmt"
 	"github.com/datreeio/datree/pkg/extractor"
-	"github.com/datreeio/datree/pkg/utils"
 	kubeconformValidator "github.com/yannh/kubeconform/pkg/validator"
 	"io"
 	"net/http"
@@ -156,6 +155,10 @@ func (val *K8sValidator) validateResource(filepath string) (bool, []error, *vali
 
 	defer f.Close()
 
+	if val.isOffline && !val.areThereCustomSchemaLocations {
+		return true, []error{}, noConnectionWarning, nil
+	}
+
 	results := val.validationClient.Validate(filepath, f)
 
 	// Return an error if no valid configurations found
@@ -174,9 +177,6 @@ func (val *K8sValidator) validateResource(filepath string) (bool, []error, *vali
 			isAtLeastOneConfigSkipped = true
 		}
 		if res.Status == kubeconformValidator.Invalid || res.Status == kubeconformValidator.Error {
-			if utils.IsNetworkError(res.Err.Error()) {
-				return true, []error{}, noConnectionWarning, nil
-			}
 			isValid = false
 
 			errorMessages := strings.Split(res.Err.Error(), "-")

--- a/bl/validation/k8sValidator.go
+++ b/bl/validation/k8sValidator.go
@@ -2,14 +2,15 @@ package validation
 
 import (
 	"fmt"
-	"github.com/datreeio/datree/pkg/extractor"
-	"github.com/datreeio/datree/pkg/utils"
-	kubeconformValidator "github.com/yannh/kubeconform/pkg/validator"
 	"io"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/datreeio/datree/pkg/extractor"
+	"github.com/datreeio/datree/pkg/utils"
+	kubeconformValidator "github.com/yannh/kubeconform/pkg/validator"
 )
 
 var noConnectionWarning = &validationWarning{

--- a/bl/validation/k8sValidator.go
+++ b/bl/validation/k8sValidator.go
@@ -13,11 +13,6 @@ import (
 	kubeconformValidator "github.com/yannh/kubeconform/pkg/validator"
 )
 
-var noConnectionWarning = &validationWarning{
-	WarningKind:    NetworkError,
-	WarningMessage: "k8s schema validation skipped: no internet connection",
-}
-
 type ValidationClient interface {
 	Validate(filename string, r io.ReadCloser) []kubeconformValidator.Result
 }
@@ -158,6 +153,10 @@ func (val *K8sValidator) validateResource(filepath string) (bool, []error, *vali
 	defer f.Close()
 
 	if val.isOffline && !val.areThereCustomSchemaLocations {
+		var noConnectionWarning = &validationWarning{
+			WarningKind:    NetworkError,
+			WarningMessage: "k8s schema validation skipped: no internet connection",
+		}
 		return true, []error{}, noConnectionWarning, nil
 	}
 

--- a/bl/validation/k8sValidator_test.go
+++ b/bl/validation/k8sValidator_test.go
@@ -30,7 +30,7 @@ func TestValidateResources(t *testing.T) {
 	test_get_datree_crd_schema_by_name(t)
 	t.Run("test empty file", test_empty_file)
 	t.Run("test no internet connection", test_offline_without_custom_schema_locations)
-	t.Run("test no internet connection", test_offline_with_custom_schema_location)
+	t.Run("test no internet connection", test_offline_with_remote_custom_schema_location)
 	t.Run("test missing schema skipped", test_missing_schema_skipped)
 }
 
@@ -160,7 +160,7 @@ func test_offline_without_custom_schema_locations(t *testing.T) {
 	assert.Equal(t, "k8s schema validation skipped: no internet connection", k8sValidationWarningPerValidFile[path].Warning)
 }
 
-func test_offline_with_custom_schema_location(t *testing.T) {
+func test_offline_with_remote_custom_schema_location(t *testing.T) {
 	validationClient := &mockValidationClient{}
 	validationClient.On("Validate", mock.Anything, mock.Anything).Return([]kubeconformValidator.Result{
 		{Status: kubeconformValidator.Error, Err: fmt.Errorf("no such host")},

--- a/bl/validation/k8sValidator_test.go
+++ b/bl/validation/k8sValidator_test.go
@@ -25,7 +25,8 @@ func TestValidateResources(t *testing.T) {
 	test_valid_multiple_configurations(t)
 	test_valid_multiple_configurations_only_k8s_files(t)
 	test_invalid_file(t)
-	test_get_all_schema_locations(t)
+	test_get_all_schema_locations_online(t)
+	test_get_all_schema_locations_offline(t)
 	test_get_datree_crd_schema_by_name(t)
 	t.Run("test empty file", test_empty_file)
 	t.Run("test no internet connection", test_no_connection)
@@ -210,7 +211,7 @@ func test_missing_schema_skipped(t *testing.T) {
 	assert.Equal(t, "k8s schema validation skipped: --ignore-missing-schemas flag was used", k8sValidationWarningPerValidFile[path].Warning)
 }
 
-func test_get_all_schema_locations(t *testing.T) {
+func test_get_all_schema_locations_online(t *testing.T) {
 	expectedOutput := []string{
 		"/my-local-schema-location",
 		"default",
@@ -218,6 +219,14 @@ func test_get_all_schema_locations(t *testing.T) {
 		"https://raw.githubusercontent.com/datreeio/CRDs-catalog/master/argo/{{ .ResourceKind }}_{{ .ResourceAPIVersion }}.json",
 	}
 	actual := getAllSchemaLocations([]string{"/my-local-schema-location"}, false)
+	assert.Equal(t, expectedOutput, actual)
+}
+
+func test_get_all_schema_locations_offline(t *testing.T) {
+	expectedOutput := []string{
+		"/my-local-schema-location",
+	}
+	actual := getAllSchemaLocations([]string{"/my-local-schema-location"}, true)
 	assert.Equal(t, expectedOutput, actual)
 }
 

--- a/bl/validation/k8sValidator_test.go
+++ b/bl/validation/k8sValidator_test.go
@@ -215,7 +215,7 @@ func test_get_all_schema_locations(t *testing.T) {
 		"https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{ .NormalizedKubernetesVersion }}/{{ .ResourceKind }}{{ .KindSuffix }}.json",
 		"https://raw.githubusercontent.com/datreeio/CRDs-catalog/master/argo/{{ .ResourceKind }}_{{ .ResourceAPIVersion }}.json",
 	}
-	actual := getAllSchemaLocations([]string{"/my-local-schema-location"})
+	actual := getAllSchemaLocations([]string{"/my-local-schema-location"}, false)
 	assert.Equal(t, expectedOutput, actual)
 }
 

--- a/bl/validation/k8sValidator_test.go
+++ b/bl/validation/k8sValidator_test.go
@@ -134,7 +134,9 @@ func test_no_connection(t *testing.T) {
 		{Status: kubeconformValidator.Error, Err: fmt.Errorf("no such host")},
 	})
 	k8sValidator := K8sValidator{
-		validationClient: validationClient,
+		validationClient:              validationClient,
+		areThereCustomSchemaLocations: false,
+		isOffline:                     true,
 	}
 
 	path := "../../internal/fixtures/kube/pass-all.yaml"


### PR DESCRIPTION
### use cases:

**offline mode:** 
uses *only* the schema locations provided by the user
- no `--schema-location` provided: skips k8s validation with warning
- local `--schema-location` provided: validates normally
- remote `--schema-location` provided: will fail because of no internet and display the error message in the correct format

**online mode:** 
gives precedence to schema locations provided by the user, uses Datree's default schema locations as a fallback