### PR TITLE
fix: fixes for UTF-8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It’s far more effective than manual processes, such as sending an email to a s
 
 ## ⚙️ How it Works
 
-The CLI integration provides a policy enforcement solution for Kubernetes to run automatic checks on every code change for rule violations and misconfigurations. When rule violations are found, Datree produces an alert that guides the developer to fix the issue inside the CI process — or even earlier as a pre-commit hook — while explaining the reason behind the rule.
+The CLI integration provides a policy enforcement solution for Kubernetes to run automatic checks on every code change for rule violations and misconfigurations. When rule violations are found, Datree produces an alert that guides the developer to fix the issue inside the CI process - or even earlier as a pre-commit hook - while explaining the reason behind the rule.
 
 ## ⏩ Quick-start in two steps
 

--- a/internal/fixtures/junit_support/datree_test_junit.xml
+++ b/internal/fixtures/junit_support/datree_test_junit.xml
@@ -4,12 +4,12 @@
 		<testcase name="Allows pods to undergo least voluntary disruption" classname="PODDISRUPTIONBUDGET_DENY_ZERO_VOLUNTARY_DISRUPTION"></testcase>
 		<testcase name="Prevent container security vulnerability (CVE-2021-25741)" classname="CONTAINER_CVE2021_25741_INCORRECT_SUBPATH_KEY"></testcase>
 		<testcase name="Ensure each container image has a pinned (tag) version" classname="CONTAINERS_MISSING_IMAGE_VALUE_VERSION">
-			<failure message="Incorrect value for key `image` - specify an image version to avoid unpleasant &#34;version surprises&#34; in the future">1 occurrences&#xA;— metadata.name: rss-site (kind: Deployment)&#xA;0 skipped&#xA;</failure>
+			<failure message="Incorrect value for key `image` - specify an image version to avoid unpleasant &#34;version surprises&#34; in the future">1 occurrences&#xA;- metadata.name: rss-site (kind: Deployment)&#xA;0 skipped&#xA;</failure>
 		</testcase>
 		<testcase name="Ensure each container has a configured memory request" classname="CONTAINERS_MISSING_MEMORY_REQUEST_KEY"></testcase>
 		<testcase name="Ensure each container has a configured CPU request" classname="CONTAINERS_MISSING_CPU_REQUEST_KEY"></testcase>
 		<testcase name="Ensure each container has a configured memory limit" classname="CONTAINERS_MISSING_MEMORY_LIMIT_KEY">
-			<failure message="Missing property object `limits.memory` - value should be within the accepted boundaries recommended by the organization">1 occurrences&#xA;— metadata.name: rss-site (kind: Deployment)&#xA;0 skipped&#xA;</failure>
+			<failure message="Missing property object `limits.memory` - value should be within the accepted boundaries recommended by the organization">1 occurrences&#xA;- metadata.name: rss-site (kind: Deployment)&#xA;0 skipped&#xA;</failure>
 		</testcase>
 		<testcase name="Ensure each container has a configured CPU limit" classname="CONTAINERS_MISSING_CPU_LIMIT_KEY"></testcase>
 		<testcase name="Prevent Ingress from forwarding all traffic to a single container" classname="INGRESS_INCORRECT_HOST_VALUE_PERMISSIVE"></testcase>
@@ -17,12 +17,12 @@
 		<testcase name="Ensure CronJob scheduler is valid" classname="CRONJOB_INVALID_SCHEDULE_VALUE"></testcase>
 		<testcase name="Ensure workload has valid label values" classname="WORKLOAD_INVALID_LABELS_VALUE">
 			<skipped message="All failing configs skipped"></skipped>
-			<failure message="Incorrect value for key(s) under `labels` - the vales syntax is not valid so the Kubernetes engine will not accept it">1 occurrences&#xA;— metadata.name: rss-site (kind: Deployment)&#xA;1 skipped&#xA;— metadata.name: rss-site (kind: Deployment)&#xA;</failure>
+			<failure message="Incorrect value for key(s) under `labels` - the vales syntax is not valid so the Kubernetes engine will not accept it">1 occurrences&#xA;- metadata.name: rss-site (kind: Deployment)&#xA;1 skipped&#xA;- metadata.name: rss-site (kind: Deployment)&#xA;</failure>
 		</testcase>
 		<testcase name="Ensure deployment-like resource is using a valid restart policy" classname="WORKLOAD_INCORRECT_RESTARTPOLICY_VALUE_ALWAYS"></testcase>
 		<testcase name="Ensure each container has a configured liveness probe" classname="CONTAINERS_MISSING_LIVENESSPROBE_KEY">
 			<skipped message="All failing configs skipped"></skipped>
-			<failure message="Missing property object `livenessProbe` - add a properly configured livenessProbe to catch possible deadlocks">1 occurrences&#xA;— metadata.name: rss-site (kind: Deployment)&#xA;1 skipped&#xA;— metadata.name: rss-site (kind: Deployment)&#xA;</failure>
+			<failure message="Missing property object `livenessProbe` - add a properly configured livenessProbe to catch possible deadlocks">1 occurrences&#xA;- metadata.name: rss-site (kind: Deployment)&#xA;1 skipped&#xA;- metadata.name: rss-site (kind: Deployment)&#xA;</failure>
 		</testcase>
 		<testcase name="Ensure each container has a configured readiness probe" classname="CONTAINERS_MISSING_READINESSPROBE_KEY"></testcase>
 		<testcase name="Ensure HPA has minimum replicas configured" classname="HPA_MISSING_MINREPLICAS_KEY"></testcase>
@@ -35,10 +35,10 @@
 		<testcase name="Prevent containers from having root access capabilities" classname="CONTAINERS_INCORRECT_PRIVILEGED_VALUE_TRUE"></testcase>
 		<testcase name="Ensure workload has a configured `owner` label" classname="WORKLOAD_MISSING_LABEL_OWNER_VALUE"></testcase>
 		<testcase name="Ensure Deployment has a configured `env` label" classname="DEPLOYMENT_MISSING_LABEL_ENV_VALUE">
-			<failure message="Missing label object `env` - add a proper environment description (e.g. &#34;prod&#34;, &#34;testing&#34;, etc.) to the Deployment config">1 occurrences&#xA;— metadata.name: rss-site (kind: Deployment)&#xA;0 skipped&#xA;</failure>
+			<failure message="Missing label object `env` - add a proper environment description (e.g. &#34;prod&#34;, &#34;testing&#34;, etc.) to the Deployment config">1 occurrences&#xA;- metadata.name: rss-site (kind: Deployment)&#xA;0 skipped&#xA;</failure>
 		</testcase>
 		<testcase name="Ensure each container image has a digest tag" classname="CONTAINERS_MISSING_IMAGE_VALUE_DIGEST">
-			<failure message="Incorrect value for key `image` - add a digest tag (starts with `@sha256:`) to represent an immutable version of the image">1 occurrences&#xA;— metadata.name: rss-site (kind: Deployment)&#xA;0 skipped&#xA;</failure>
+			<failure message="Incorrect value for key `image` - add a digest tag (starts with `@sha256:`) to represent an immutable version of the image">1 occurrences&#xA;- metadata.name: rss-site (kind: Deployment)&#xA;0 skipped&#xA;</failure>
 		</testcase>
 		<testcase name="Prevent CronJob from executing jobs concurrently" classname="CRONJOB_MISSING_CONCURRENCYPOLICY_KEY"></testcase>
 		<testcase name="Prevent deploying naked pods" classname="K8S_INCORRECT_KIND_VALUE_POD"></testcase>

--- a/internal/fixtures/junit_support/datree_test_junit_report.html
+++ b/internal/fixtures/junit_support/datree_test_junit_report.html
@@ -732,7 +732,7 @@ h1 {
 
                         
                         <pre>1 occurrences
-— metadata.name: rss-site (kind: Deployment)
+- metadata.name: rss-site (kind: Deployment)
 0 skipped
 </pre>
                         
@@ -822,7 +822,7 @@ h1 {
 
                         
                         <pre>1 occurrences
-— metadata.name: rss-site (kind: Deployment)
+- metadata.name: rss-site (kind: Deployment)
 0 skipped
 </pre>
                         
@@ -972,9 +972,9 @@ h1 {
 
                         
                         <pre>1 occurrences
-— metadata.name: rss-site (kind: Deployment)
+- metadata.name: rss-site (kind: Deployment)
 1 skipped
-— metadata.name: rss-site (kind: Deployment)
+- metadata.name: rss-site (kind: Deployment)
 </pre>
                         
                         
@@ -1038,9 +1038,9 @@ h1 {
 
                         
                         <pre>1 occurrences
-— metadata.name: rss-site (kind: Deployment)
+- metadata.name: rss-site (kind: Deployment)
 1 skipped
-— metadata.name: rss-site (kind: Deployment)
+- metadata.name: rss-site (kind: Deployment)
 </pre>
                         
                         
@@ -1363,7 +1363,7 @@ h1 {
 
                         
                         <pre>1 occurrences
-— metadata.name: rss-site (kind: Deployment)
+- metadata.name: rss-site (kind: Deployment)
 0 skipped
 </pre>
                         
@@ -1395,7 +1395,7 @@ h1 {
 
                         
                         <pre>1 occurrences
-— metadata.name: rss-site (kind: Deployment)
+- metadata.name: rss-site (kind: Deployment)
 0 skipped
 </pre>
                         

--- a/pkg/evaluation/junit_output.go
+++ b/pkg/evaluation/junit_output.go
@@ -201,7 +201,7 @@ func getContentFromOccurrencesDetails(occurrencesDetails []OccurrenceDetails) st
 	var skipLines string
 
 	for _, occurrenceDetails := range occurrencesDetails {
-		currentLine := "— metadata.name: " + occurrenceDetails.MetadataName + " (kind: " + occurrenceDetails.Kind + ")\n"
+		currentLine := "- metadata.name: " + occurrenceDetails.MetadataName + " (kind: " + occurrenceDetails.Kind + ")\n"
 
 		totalOccurrences += occurrenceDetails.Occurrences
 		occurrencesLines += currentLine

--- a/pkg/evaluation/printer.go
+++ b/pkg/evaluation/printer.go
@@ -375,7 +375,7 @@ func (t OutputTitle) String() string {
 
 func buildEnabledRulesTitle(policyName string) string {
 	var str strings.Builder
-	fmt.Fprintf(&str, "Enabled rules in policy “%s”", policyName)
+	fmt.Fprintf(&str, "Enabled rules in policy \"%s\"", policyName)
 	return str.String()
 }
 

--- a/pkg/evaluation/printer_test_expected_outputs/JUnit_output.xml
+++ b/pkg/evaluation/printer_test_expected_outputs/JUnit_output.xml
@@ -2,23 +2,23 @@
 <testsuites name="Default" tests="21" failures="4" skipped="0">
 	<testsuite name="File1">
 		<testcase name="Ensure each container image has a pinned (tag) version" classname="CONTAINERS_MISSING_IMAGE_VALUE_VERSION">
-			<failure message="Incorrect value for key `image` - specify an image version to avoid unpleasant &#34;version surprises&#34; in the future">1 occurrences&#xA;— metadata.name: rss-site (kind: Deployment)&#xA;0 skipped&#xA;</failure>
+			<failure message="Incorrect value for key `image` - specify an image version to avoid unpleasant &#34;version surprises&#34; in the future">1 occurrences&#xA;- metadata.name: rss-site (kind: Deployment)&#xA;0 skipped&#xA;</failure>
 		</testcase>
 		<testcase name="Ensure each container has a configured memory request" classname="CONTAINERS_MISSING_MEMORY_REQUEST_KEY"></testcase>
 		<testcase name="Ensure each container has a configured CPU request" classname="CONTAINERS_MISSING_CPU_REQUEST_KEY"></testcase>
 		<testcase name="Ensure each container has a configured memory limit" classname="CONTAINERS_MISSING_MEMORY_LIMIT_KEY">
-			<failure message="Missing property object `limits.memory` - value should be within the accepted boundaries recommended by the organization">1 occurrences&#xA;— metadata.name: rss-site (kind: Deployment)&#xA;0 skipped&#xA;</failure>
+			<failure message="Missing property object `limits.memory` - value should be within the accepted boundaries recommended by the organization">1 occurrences&#xA;- metadata.name: rss-site (kind: Deployment)&#xA;0 skipped&#xA;</failure>
 		</testcase>
 		<testcase name="Ensure each container has a configured CPU limit" classname="CONTAINERS_MISSING_CPU_LIMIT_KEY"></testcase>
 		<testcase name="Prevent Ingress from forwarding all traffic to a single container" classname="INGRESS_INCORRECT_HOST_VALUE_PERMISSIVE"></testcase>
 		<testcase name="Prevent Service from exposing node port" classname="SERVICE_INCORRECT_TYPE_VALUE_NODEPORT"></testcase>
 		<testcase name="Ensure CronJob scheduler is valid" classname="CRONJOB_INVALID_SCHEDULE_VALUE"></testcase>
 		<testcase name="Ensure workload has valid label values" classname="WORKLOAD_INVALID_LABELS_VALUE">
-			<failure message="Incorrect value for key(s) under `labels` - the vales syntax is not valid so the Kubernetes engine will not accept it">1 occurrences&#xA;— metadata.name: rss-site (kind: Deployment)&#xA;0 skipped&#xA;</failure>
+			<failure message="Incorrect value for key(s) under `labels` - the vales syntax is not valid so the Kubernetes engine will not accept it">1 occurrences&#xA;- metadata.name: rss-site (kind: Deployment)&#xA;0 skipped&#xA;</failure>
 		</testcase>
 		<testcase name="Ensure deployment-like resource is using a valid restart policy" classname="WORKLOAD_INCORRECT_RESTARTPOLICY_VALUE_ALWAYS"></testcase>
 		<testcase name="Ensure each container has a configured liveness probe" classname="CONTAINERS_MISSING_LIVENESSPROBE_KEY">
-			<failure message="Missing property object `livenessProbe` - add a properly configured livenessProbe to catch possible deadlocks">1 occurrences&#xA;— metadata.name: rss-site (kind: Deployment)&#xA;0 skipped&#xA;</failure>
+			<failure message="Missing property object `livenessProbe` - add a properly configured livenessProbe to catch possible deadlocks">1 occurrences&#xA;- metadata.name: rss-site (kind: Deployment)&#xA;0 skipped&#xA;</failure>
 		</testcase>
 		<testcase name="Ensure each container has a configured readiness probe" classname="CONTAINERS_MISSING_READINESSPROBE_KEY"></testcase>
 		<testcase name="Ensure HPA has minimum replicas configured" classname="HPA_MISSING_MINREPLICAS_KEY"></testcase>

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -279,17 +279,17 @@ func (p *Printer) GetSummaryTableText(summary Summary) string {
 	skipRow := []string{summary.SkipRow.LeftCol, summary.SkipRow.RightCol}
 	errorRow := []string{summary.ErrorRow.LeftCol, summary.ErrorRow.RightCol}
 	successRow := []string{summary.SuccessRow.LeftCol, summary.SuccessRow.RightCol}
-	
+
 	if p.Theme.Name == "Simple" {
 		summaryTable.Append(skipRow)
 		summaryTable.Append(errorRow)
 		summaryTable.Append(successRow)
-	} else {		
+	} else {
 		summaryTable.Rich(skipRow, []tablewriter.Colors{{int(p.Theme.ColorsAttributes.Cyan)}, {int(p.Theme.ColorsAttributes.Cyan)}})
 		summaryTable.Rich(errorRow, []tablewriter.Colors{{int(p.Theme.ColorsAttributes.Red)}, {int(p.Theme.ColorsAttributes.Red)}})
 		summaryTable.Rich(successRow, []tablewriter.Colors{{int(p.Theme.ColorsAttributes.Green)}, {int(p.Theme.ColorsAttributes.Green)}})
 	}
-	
+
 	rowIndex = rowIndex + 3
 
 	for plainRowsIndex < len(summary.PlainRows) && summary.PlainRows[plainRowsIndex].RowIndex >= rowIndex {

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -277,16 +277,20 @@ func (p *Printer) GetSummaryTableText(summary Summary) string {
 	}
 
 	skipRow := []string{summary.SkipRow.LeftCol, summary.SkipRow.RightCol}
-	summaryTable.Rich(skipRow, []tablewriter.Colors{{int(p.Theme.ColorsAttributes.Cyan)}, {int(p.Theme.ColorsAttributes.Cyan)}})
-	rowIndex++
-
 	errorRow := []string{summary.ErrorRow.LeftCol, summary.ErrorRow.RightCol}
-	summaryTable.Rich(errorRow, []tablewriter.Colors{{int(p.Theme.ColorsAttributes.Red)}, {int(p.Theme.ColorsAttributes.Red)}})
-	rowIndex++
-
 	successRow := []string{summary.SuccessRow.LeftCol, summary.SuccessRow.RightCol}
-	summaryTable.Rich(successRow, []tablewriter.Colors{{int(p.Theme.ColorsAttributes.Green)}, {int(p.Theme.ColorsAttributes.Green)}})
-	rowIndex++
+	
+	if p.Theme.Name == "Simple" {
+		summaryTable.Append(skipRow)
+		summaryTable.Append(errorRow)
+		summaryTable.Append(successRow)
+	} else {		
+		summaryTable.Rich(skipRow, []tablewriter.Colors{{int(p.Theme.ColorsAttributes.Cyan)}, {int(p.Theme.ColorsAttributes.Cyan)}})
+		summaryTable.Rich(errorRow, []tablewriter.Colors{{int(p.Theme.ColorsAttributes.Red)}, {int(p.Theme.ColorsAttributes.Red)}})
+		summaryTable.Rich(successRow, []tablewriter.Colors{{int(p.Theme.ColorsAttributes.Green)}, {int(p.Theme.ColorsAttributes.Green)}})
+	}
+	
+	rowIndex = rowIndex + 3
 
 	for plainRowsIndex < len(summary.PlainRows) && summary.PlainRows[plainRowsIndex].RowIndex >= rowIndex {
 		summaryTable.Append([]string{summary.PlainRows[plainRowsIndex].LeftCol, summary.PlainRows[plainRowsIndex].RightCol})

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -177,7 +177,7 @@ func (p *Printer) GetWarningsText(warnings []Warning) string {
 				}
 
 				for _, occurrenceDetails := range skippedRule.OccurrencesDetails {
-					sb.WriteString(fmt.Sprintf("    — metadata.name: %v (kind: %v)\n", p.getStringOrNotAvailableText(occurrenceDetails.MetadataName), p.getStringOrNotAvailableText(occurrenceDetails.Kind)))
+					sb.WriteString(fmt.Sprintf("    - metadata.name: %v (kind: %v)\n", p.getStringOrNotAvailableText(occurrenceDetails.MetadataName), p.getStringOrNotAvailableText(occurrenceDetails.Kind)))
 					m := p.Theme.Colors.White.Sprint(occurrenceDetails.SkipMessage)
 					sb.WriteString(fmt.Sprintf("%v %v\n", p.Theme.Emoji.Suggestion, m))
 				}
@@ -206,7 +206,7 @@ func (p *Printer) GetWarningsText(warnings []Warning) string {
 				}
 
 				for _, occurrenceDetails := range failedRule.OccurrencesDetails {
-					sb.WriteString(fmt.Sprintf("    — metadata.name: %v (kind: %v)\n", p.getStringOrNotAvailableText(occurrenceDetails.MetadataName), p.getStringOrNotAvailableText(occurrenceDetails.Kind)))
+					sb.WriteString(fmt.Sprintf("    - metadata.name: %v (kind: %v)\n", p.getStringOrNotAvailableText(occurrenceDetails.MetadataName), p.getStringOrNotAvailableText(occurrenceDetails.Kind)))
 				}
 				sb.WriteString(fmt.Sprintf("%v %v\n", p.Theme.Emoji.Suggestion, failedRule.Suggestion))
 

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -56,7 +56,7 @@ func TestGetWarningsText(t *testing.T) {
 [X] Policy check
 
 ❌  Caption  [1 occurrence]
-    — metadata.name: yishay (kind: Pod)
+    - metadata.name: yishay (kind: Pod)
 💡  Suggestion
 
 >>  File: /datree/datree/internal/fixtures/kube/yaml-validation-error.yaml
@@ -112,7 +112,7 @@ https://github.com/datreeio/helm-datree
 [X] Policy check
 
 [X]  Caption  [1 occurrence]
-    — metadata.name: yishay (kind: Pod)
+    - metadata.name: yishay (kind: Pod)
 [*]  Suggestion
 
 >>  File: /datree/datree/internal/fixtures/kube/yaml-validation-error.yaml

--- a/pkg/printer/theme.go
+++ b/pkg/printer/theme.go
@@ -8,6 +8,7 @@ import (
 )
 
 type Theme struct {
+	Name string
 	Colors struct {
 		Green     *color.Color
 		Yellow    *color.Color
@@ -35,6 +36,7 @@ type Theme struct {
 
 func createDefaultTheme() *Theme {
 	return &Theme{
+		Name: "Default",
 		Colors: struct {
 			Green     *color.Color
 			Yellow    *color.Color
@@ -79,6 +81,7 @@ func createDefaultTheme() *Theme {
 }
 func CreateSimpleTheme() *Theme {
 	return &Theme{
+		Name: "Simple",
 		Colors: struct {
 			Green     *color.Color
 			Yellow    *color.Color

--- a/pkg/printer/theme.go
+++ b/pkg/printer/theme.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Theme struct {
-	Name string
+	Name   string
 	Colors struct {
 		Green     *color.Color
 		Yellow    *color.Color


### PR DESCRIPTION
* Swap `—` with `-`
* `“` and `”` with `"`
* Only use `Rich` coloured table when not in `simple` output mode

Fixes #646 