### PR TITLE
feat: update CRD name in the catalog to argoproj

### DIFF
--- a/bl/validation/k8sValidator.go
+++ b/bl/validation/k8sValidator.go
@@ -230,7 +230,7 @@ func getDefaultSchemaLocations() []string {
 		// this is a workaround for https://github.com/yannh/kubeconform/issues/100
 		// notice: order here is important because this fallback doesn't have strict mode enabled (in contrast to "default")
 		"https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{ .NormalizedKubernetesVersion }}/{{ .ResourceKind }}{{ .KindSuffix }}.json",
-		getDatreeCRDSchemaByName("argo"),
+		getDatreeCRDSchemaByName("argoproj"),
 	}
 }
 

--- a/bl/validation/k8sValidator_test.go
+++ b/bl/validation/k8sValidator_test.go
@@ -206,7 +206,7 @@ func test_get_all_schema_locations_online(t *testing.T) {
 		"/my-local-schema-location",
 		"default",
 		"https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{ .NormalizedKubernetesVersion }}/{{ .ResourceKind }}{{ .KindSuffix }}.json",
-		"https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/argo/{{ .ResourceKind }}_{{ .ResourceAPIVersion }}.json",
+		"https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/argoproj/{{ .ResourceKind }}_{{ .ResourceAPIVersion }}.json",
 	}
 	actual := getAllSchemaLocations([]string{"/my-local-schema-location"}, false)
 	assert.Equal(t, expectedOutput, actual)


### PR DESCRIPTION
we changed the naming convention in the CRDs-catalog project so now the name of the dir is `argoproj`:
https://github.com/datreeio/CRDs-catalog/tree/main/argoproj