### PR TITLE
fix: don't ignore annotations when metadata.name doesn't exist 

### DIFF
--- a/pkg/evaluation/evaluator.go
+++ b/pkg/evaluation/evaluator.go
@@ -356,10 +356,6 @@ func addFailedRule(currentFailedRulesByFiles FailedRulesByFiles, fileName string
 func extractSkipAnnotations(configuration extractor.Configuration) map[string]string {
 	skipAnnotations := make(map[string]string)
 
-	if configuration.MetadataName == "" || configuration.Kind == "" {
-		return nil
-	}
-
 	for annotationKey, annotationValue := range configuration.Annotations {
 		if strings.Contains(annotationKey, SKIP_RULE_PREFIX) {
 			skipAnnotations[annotationKey] = annotationValue.(string)

--- a/pkg/extractor/extractor.go
+++ b/pkg/extractor/extractor.go
@@ -130,9 +130,10 @@ func extractConfigurationK8sData(content []byte) Configuration {
 	if metadata := jsonObject["metadata"]; metadata != nil {
 		if metadataName := metadata.(map[string]interface{})["name"]; metadataName != nil {
 			configuration.MetadataName = metadataName.(string)
-			if annotations := metadata.(map[string]interface{})["annotations"]; annotations != nil {
-				configuration.Annotations = annotations.(map[string]interface{})
-			}
+		}
+
+		if annotations := metadata.(map[string]interface{})["annotations"]; annotations != nil {
+			configuration.Annotations = annotations.(map[string]interface{})
 		}
 	}
 


### PR DESCRIPTION
don't ignore annotations if metadata.name is missing and verify annotations property is present in metadata instead of metadata.name