### PR TITLE
fix: update RESOURCE_MISSING_NAME logic

### DIFF
--- a/pkg/defaultRules/defaultRules.yaml
+++ b/pkg/defaultRules/defaultRules.yaml
@@ -1565,9 +1565,16 @@ rules:
                 - generateName
           required:
             - metadata
-      anyOf:
-        - $ref: "#/definitions/metadataNamePattern"
-        - $ref: "#/definitions/metadataGenerateNamePattern"
+      if:
+        properties:
+          kind:
+            not:
+              enum:
+                - Kustomization
+      then:
+        anyOf:
+          - $ref: "#/definitions/metadataNamePattern"
+          - $ref: "#/definitions/metadataGenerateNamePattern"
   - id: 55
     name: Ensure each container probe has an initial delay configured
     uniqueName: CONTAINERS_INCORRECT_INITIALDELAYSECONDS_VALUE


### PR DESCRIPTION
Kustomization objects don't require key `name` or `generateName` to be valid K8s objects.
Therefore, I updated the rule logic to ignore objects `kind: Kustomization` when ensuring the object name exists.