### PR TITLE
fix: slice bounds out of range on failure location printer

### DIFF
--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -210,8 +210,10 @@ func (p *Printer) GetWarningsText(warnings []Warning) string {
 				for _, occurrenceDetails := range failedRule.OccurrencesDetails {
 					sb.WriteString(fmt.Sprintf("    - metadata.name: %v (kind: %v)\n", p.getStringOrNotAvailableText(occurrenceDetails.MetadataName), p.getStringOrNotAvailableText(occurrenceDetails.Kind)))
 					for _, validationResult := range occurrenceDetails.FailureLocations {
-						failurePath := fmt.Sprintf("%v (line: %d:%d)\n", strings.Replace(validationResult.SchemaPath, "/", ".", -1)[1:], validationResult.FailedErrorLine, validationResult.FailedErrorColumn)
-						sb.WriteString(fmt.Sprintf("      > key: %v", failurePath))
+						if validationResult.SchemaPath != "" {
+							failurePath := fmt.Sprintf("%v (line: %d:%d)\n", strings.Replace(validationResult.SchemaPath, "/", ".", -1), validationResult.FailedErrorLine, validationResult.FailedErrorColumn)
+							sb.WriteString(fmt.Sprintf("      > key: %v", failurePath))
+						}
 					}
 					sb.WriteString("\n")
 

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -211,7 +211,7 @@ func (p *Printer) GetWarningsText(warnings []Warning) string {
 					sb.WriteString(fmt.Sprintf("    - metadata.name: %v (kind: %v)\n", p.getStringOrNotAvailableText(occurrenceDetails.MetadataName), p.getStringOrNotAvailableText(occurrenceDetails.Kind)))
 					for _, validationResult := range occurrenceDetails.FailureLocations {
 						if validationResult.SchemaPath != "" {
-							failurePath := fmt.Sprintf("%v (line: %d:%d)\n", strings.Replace(validationResult.SchemaPath, "/", ".", -1), validationResult.FailedErrorLine, validationResult.FailedErrorColumn)
+							failurePath := fmt.Sprintf("%v (line: %d:%d)\n", strings.Replace(validationResult.SchemaPath, "/", ".", -1)[1:], validationResult.FailedErrorLine, validationResult.FailedErrorColumn)
 							sb.WriteString(fmt.Sprintf("      > key: %v", failurePath))
 						}
 					}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29673827/188319249-8a9d772c-3a87-4ee6-9353-acceaabde95d.png)
test case yaml: 
https://github.com/datreeio/CRDs-catalog/blob/main/argoproj.io/application_v1alpha1.json
change metadata.name to something wrong like "namee" and you should see the 'slice' error

