### PR TITLE
refactor: make release candidate version a required parameter on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       release_candidate_version:
         description: "Release Candidate Version:"
-        required: false
+        required: true
 
 jobs:
   define_version_job:


### PR DESCRIPTION
releasing a production version of datree without providing a release_candidate_version does not currently work, therefore to avoid confusion I'm making it required