### PR TITLE
fix: resolve schema error in demo file

### DIFF
--- a/internal/fixtures/kube/k8s-demo.yaml
+++ b/internal/fixtures/kube/k8s-demo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rss-site
   namespace: test
   labels:
-    owner: --
+    owner: yoda-at-datree.io
     environment: prod
     app: web
 spec:

--- a/internal/fixtures/kube/k8s-demo.yaml
+++ b/internal/fixtures/kube/k8s-demo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rss-site
   namespace: test
   labels:
-    owner: yoda-at-datree.io
+    owner: yoda@datree.io
     environment: prod
     app: web
 spec:


### PR DESCRIPTION
The k8s-demo-file has an invalid owner name that fails the schema validation 