### PR TITLE
feat: add docs command for datree #763 

### DIFF
--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -24,7 +24,7 @@ func New(ctx *DocsCommandContext) *cobra.Command {
 		Short:   "Open datree documentation page",
 		Long:    "Open the default browser with datree documentation page",
 		Aliases: []string{"documentation"},
-		Example: (`
+		Example: utils.Example(`
 		# Open documentation with 'docs'
 		datree docs
 

--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -1,16 +1,24 @@
 package docs
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/datreeio/datree/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
-const DEFAULT_ERR_EXIT_CODE = 1
+type DocsCommandContext struct {
+	BrowserCtx utils.OpenBrowserContext
+	URL        string
+}
 
-func New() *cobra.Command {
+func (do *DocsCommandContext) OpenURL(url string) error {
+	err := do.BrowserCtx.OpenBrowser(url)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func New(ctx *DocsCommandContext) *cobra.Command {
 	var docsCmd = &cobra.Command{
 		Use:     "docs",
 		Short:   "Open datree documentation page",
@@ -23,13 +31,15 @@ func New() *cobra.Command {
 		# Open documentation with alias 'documentation'
 		datree documentation
 		`),
-		Run: func(cmd *cobra.Command, args []string) {
-			url := "https://hub.datree.io"
-			err := utils.OpenBrowser(url)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(DEFAULT_ERR_EXIT_CODE)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if ctx.URL == "" {
+				ctx.URL = "https://hub.datree.io"
 			}
+			err := ctx.BrowserCtx.UrlOpener.OpenURL(ctx.URL)
+			if err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -2,16 +2,19 @@ package docs
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/datreeio/datree/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
+const DEFAULT_ERR_EXIT_CODE = 1
+
 func New() *cobra.Command {
 	var docsCmd = &cobra.Command{
 		Use:     "docs",
-		Short:   "Datree documentation",
-		Long:    "It will open a browser with datree documentation",
+		Short:   "Open datree documentation page",
+		Long:    "Open the default browser with datree documentation page",
 		Aliases: []string{"documentation"},
 		Example: (`
 		# Open documentation with 'docs'
@@ -25,6 +28,7 @@ func New() *cobra.Command {
 			err := utils.OpenBrowser(url)
 			if err != nil {
 				fmt.Println(err)
+				os.Exit(DEFAULT_ERR_EXIT_CODE)
 			}
 		},
 	}

--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -1,0 +1,28 @@
+package docs
+
+import (
+	"github.com/datreeio/datree/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+func New() *cobra.Command {
+	var docsCmd = &cobra.Command{
+		Use:     "docs",
+		Short:   "Datree documentation",
+		Long:    "It will open a browser with datree documentation",
+		Aliases: []string{"documentation"},
+		Example: (`
+		# Open documentation with 'docs'
+		datree docs
+
+		# Open documentation with alias 'documentation'
+		datree documentation
+		`),
+		Run: func(cmd *cobra.Command, args []string) {
+			url := "https://hub.datree.io"
+			utils.OpenBrowser(url)
+		},
+	}
+
+	return docsCmd
+}

--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -1,6 +1,8 @@
 package docs
 
 import (
+	"fmt"
+
 	"github.com/datreeio/datree/pkg/utils"
 	"github.com/spf13/cobra"
 )
@@ -20,7 +22,10 @@ func New() *cobra.Command {
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			url := "https://hub.datree.io"
-			utils.OpenBrowser(url)
+			err := utils.OpenBrowser(url)
+			if err != nil {
+				fmt.Println(err)
+			}
 		},
 	}
 

--- a/cmd/docs/main_test.go
+++ b/cmd/docs/main_test.go
@@ -2,7 +2,7 @@ package docs
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,7 +25,7 @@ func Test_DocsCommand(t *testing.T) {
 			cmd.SetOut(out)
 			cmd.Execute()
 
-			got, err := ioutil.ReadAll(out)
+			got, err := io.ReadAll(out)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/docs/main_test.go
+++ b/cmd/docs/main_test.go
@@ -5,22 +5,49 @@ import (
 	"io"
 	"testing"
 
+	"github.com/datreeio/datree/pkg/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
+
+type openBrowserMock struct {
+	mock.Mock
+}
+
+func (o *openBrowserMock) OpenURL(url string) error {
+	args := o.Called(url)
+	return args.Error(0)
+}
 
 func Test_DocsCommand(t *testing.T) {
 	testCases := []struct {
 		desc     string
+		url      string
 		expected []byte
 	}{
 		{
-			desc:     "Test datree docs",
+			desc:     "Test official URL",
+			url:      "https://hub.datree.io",
+			expected: []byte(`Opening https://hub.datree.io in your browser.`),
+		},
+		{
+			desc:     "Test empty URL",
+			url:      "",
 			expected: []byte(`Opening https://hub.datree.io in your browser.`),
 		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			cmd := New()
+			openBrowser := &openBrowserMock{}
+			openBrowser.On("OpenURL", mock.Anything).Return(nil)
+
+			cmd := New(&DocsCommandContext{
+				BrowserCtx: utils.OpenBrowserContext{
+					UrlOpener: openBrowser,
+				},
+				URL: tC.url,
+			})
+
 			out := bytes.NewBufferString("Opening https://hub.datree.io in your browser.")
 			cmd.SetOut(out)
 			err := cmd.Execute()

--- a/cmd/docs/main_test.go
+++ b/cmd/docs/main_test.go
@@ -23,7 +23,10 @@ func Test_DocsCommand(t *testing.T) {
 			cmd := New()
 			out := bytes.NewBufferString("Opening https://hub.datree.io in your browser.")
 			cmd.SetOut(out)
-			cmd.Execute()
+			err := cmd.Execute()
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			got, err := io.ReadAll(out)
 			if err != nil {

--- a/cmd/docs/main_test.go
+++ b/cmd/docs/main_test.go
@@ -1,0 +1,36 @@
+package docs
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_DocsCommand(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		expected []byte
+	}{
+		{
+			desc:     "Test datree docs",
+			expected: []byte(`Opening https://hub.datree.io in your browser.`),
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			cmd := New()
+			out := bytes.NewBufferString("Opening https://hub.datree.io in your browser.")
+			cmd.SetOut(out)
+			cmd.Execute()
+
+			got, err := ioutil.ReadAll(out)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, string(tC.expected), string(got))
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/datreeio/datree/pkg/evaluation"
+	"github.com/datreeio/datree/pkg/utils"
 
 	"github.com/datreeio/datree/bl/files"
 	"github.com/datreeio/datree/bl/messager"
@@ -33,22 +34,24 @@ var rootCmd = &cobra.Command{
 }
 
 var CliVersion string
+var DocUrl string
 
 func NewRootCommand(app *App) *cobra.Command {
 	startTime := time.Now()
 
 	rootCmd.AddCommand(test.New(&test.TestCommandContext{
-		CliVersion:     CliVersion,
-		Evaluator:      app.Context.Evaluator,
-		LocalConfig:    app.Context.LocalConfig,
-		Messager:       app.Context.Messager,
-		Printer:        app.Context.Printer,
-		Reader:         app.Context.Reader,
-		K8sValidator:   app.Context.K8sValidator,
-		CliClient:      app.Context.CliClient,
-		FilesExtractor: app.Context.FilesExtractor,
-		CiContext:      app.Context.CiContext,
-		StartTime:      startTime,
+		CliVersion:         CliVersion,
+		Evaluator:          app.Context.Evaluator,
+		LocalConfig:        app.Context.LocalConfig,
+		Messager:           app.Context.Messager,
+		Printer:            app.Context.Printer,
+		Reader:             app.Context.Reader,
+		K8sValidator:       app.Context.K8sValidator,
+		CliClient:          app.Context.CliClient,
+		FilesExtractor:     app.Context.FilesExtractor,
+		CiContext:          app.Context.CiContext,
+		OpenBrowserContext: utils.OpenBrowserContext{},
+		StartTime:          startTime,
 	}))
 
 	rootCmd.AddCommand(kustomize.New(&test.TestCommandContext{
@@ -94,7 +97,13 @@ func NewRootCommand(app *App) *cobra.Command {
 		Printer:             app.Context.Printer,
 	}))
 
-	rootCmd.AddCommand(docs.New())
+	rootCmd.AddCommand(docs.New(&docs.DocsCommandContext{
+		BrowserCtx: utils.OpenBrowserContext{
+			UrlOpener: &docs.DocsCommandContext{
+				URL: "https://hub.datree.io",
+			},
+		},
+	}))
 
 	return rootCmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/datreeio/datree/bl/validation"
 	"github.com/datreeio/datree/cmd/completion"
 	"github.com/datreeio/datree/cmd/config"
+	"github.com/datreeio/datree/cmd/docs"
 	"github.com/datreeio/datree/cmd/kustomize"
 	"github.com/datreeio/datree/cmd/publish"
 	schemaValidator "github.com/datreeio/datree/cmd/schema-validator"
@@ -92,6 +93,8 @@ func NewRootCommand(app *App) *cobra.Command {
 		JSONSchemaValidator: app.Context.JSONSchemaValidator,
 		Printer:             app.Context.Printer,
 	}))
+
+	rootCmd.AddCommand(docs.New())
 
 	return rootCmd
 }

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -437,7 +437,10 @@ func test(ctx *TestCommandContext, paths []string, testCommandData *TestCommandD
 		}
 
 		if strings.ToLower(string(answer)) != "n" {
-			utils.OpenBrowser(testCommandData.PromptRegistrationURL)
+			err := utils.OpenBrowser(testCommandData.PromptRegistrationURL)
+			if err != nil {
+				fmt.Println(err)
+			}
 		}
 	}
 

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -151,17 +151,18 @@ type TestCommandData struct {
 }
 
 type TestCommandContext struct {
-	CliVersion     string
-	CiContext      *ciContext.CIContext
-	LocalConfig    LocalConfig
-	Evaluator      Evaluator
-	Messager       Messager
-	K8sValidator   K8sValidator
-	Printer        EvaluationPrinter
-	Reader         Reader
-	CliClient      CliClient
-	FilesExtractor files.FilesExtractorInterface
-	StartTime      time.Time
+	CliVersion         string
+	CiContext          *ciContext.CIContext
+	LocalConfig        LocalConfig
+	Evaluator          Evaluator
+	Messager           Messager
+	K8sValidator       K8sValidator
+	Printer            EvaluationPrinter
+	Reader             Reader
+	CliClient          CliClient
+	FilesExtractor     files.FilesExtractorInterface
+	StartTime          time.Time
+	OpenBrowserContext utils.OpenBrowserContext
 }
 
 func LoadVersionMessages(ctx *TestCommandContext, args []string, cmd *cobra.Command) error {
@@ -437,9 +438,9 @@ func test(ctx *TestCommandContext, paths []string, testCommandData *TestCommandD
 		}
 
 		if strings.ToLower(string(answer)) != "n" {
-			err := utils.OpenBrowser(testCommandData.PromptRegistrationURL)
+			err := ctx.OpenBrowserContext.OpenBrowser(testCommandData.PromptRegistrationURL)
 			if err != nil {
-				fmt.Println(err)
+				return err
 			}
 		}
 	}

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -437,7 +437,7 @@ func test(ctx *TestCommandContext, paths []string, testCommandData *TestCommandD
 		}
 
 		if strings.ToLower(string(answer)) != "n" {
-			openBrowser(testCommandData.PromptRegistrationURL)
+			utils.OpenBrowser(testCommandData.PromptRegistrationURL)
 		}
 	}
 

--- a/cmd/test/testCommandHelper.go
+++ b/cmd/test/testCommandHelper.go
@@ -1,11 +1,9 @@
 package test
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/briandowns/spinner"
-	"github.com/pkg/browser"
 )
 
 func createSpinner(text string, color string) *spinner.Spinner {
@@ -13,9 +11,4 @@ func createSpinner(text string, color string) *spinner.Spinner {
 	s.Suffix = text
 	s.Color(color)
 	return s
-}
-
-func openBrowser(url string) {
-	fmt.Printf("Opening %s in your browser.\n", url)
-	browser.OpenURL(url)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"fmt"
 	"strings"
+
+	"github.com/pkg/browser"
 )
 
 func Example(s string) string {
@@ -46,4 +48,9 @@ func ValidateStdinPathArgument(paths []string) error {
 	}
 
 	return nil
+}
+
+func OpenBrowser(url string) {
+	fmt.Printf("Opening %s in your browser.\n", url)
+	browser.OpenURL(url)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -50,7 +50,11 @@ func ValidateStdinPathArgument(paths []string) error {
 	return nil
 }
 
-func OpenBrowser(url string) {
+func OpenBrowser(url string) error {
 	fmt.Printf("Opening %s in your browser.\n", url)
-	browser.OpenURL(url)
+	err := browser.OpenURL(url)
+	if err != nil {
+		return fmt.Errorf("error opening url: %v", err)
+	}
+	return nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -50,7 +50,15 @@ func ValidateStdinPathArgument(paths []string) error {
 	return nil
 }
 
-func OpenBrowser(url string) error {
+type URLOpener interface {
+	OpenURL(url string) error
+}
+
+type OpenBrowserContext struct {
+	UrlOpener URLOpener
+}
+
+func (o *OpenBrowserContext) OpenBrowser(url string) error {
 	fmt.Printf("Opening %s in your browser.\n", url)
 	err := browser.OpenURL(url)
 	if err != nil {


### PR DESCRIPTION
Added `docs` or `documentation` command that will open a browser with datree documentation. Also as per [suggestion](https://github.com/datreeio/datree/issues/763#issuecomment-1225454155) in the issue, I have moved the `OpenBroswer` function to `pkg/utils` package so it can be used to both `test` and `docs` command.

![image](https://user-images.githubusercontent.com/35197703/196498465-3a42a0e5-a6c9-4889-8327-6705f694feb3.png)
