### PR TITLE
830-fix-datree-offline-mode-error

### DIFF
--- a/pkg/utils/errors.go
+++ b/pkg/utils/errors.go
@@ -18,7 +18,7 @@ func ParseErrorToString(err interface{}) string {
 }
 
 func IsNetworkError(err error) bool {
-	networkErrors := []string{"network error", "connection refused", "no such host", "i/o timeout", "server misbehaving"}
+	networkErrors := []string{"network error", "connection refused", "no such host", "i/o timeout", "server misbehaving", "blocked"}
 	return stringInSliceContains(err.Error(), networkErrors) || isUrlErrorType(err)
 }
 


### PR DESCRIPTION
Add "blocked" to the list of network errors to resolve issue with execution in an airgapped environment.