### PR TITLE
feat:add quiet mode to CLI

### DIFF
--- a/cmd/kustomize/main_test.go
+++ b/cmd/kustomize/main_test.go
@@ -144,7 +144,7 @@ type PrinterMock struct {
 	mock.Mock
 }
 
-func (p *PrinterMock) GetWarningsText(warnings []printer.Warning) string {
+func (p *PrinterMock) GetWarningsText(warnings []printer.Warning, quiet bool) string {
 	p.Called(warnings)
 	return ""
 }

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -273,7 +273,7 @@ func (flags *TestCommandFlags) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&flags.IgnoreMissingSchemas, "ignore-missing-schemas", "", false, "Ignore missing schemas when executing schema validation step")
 	cmd.Flags().BoolVarP(&flags.SaveRendered, "save-rendered", "", false, "Don't delete rendered files after the policy check (e.g. helm, kustomize)")
 	cmd.Flags().BoolVarP(&flags.PermissiveSchema, "permissive-schema", "", false, "Perform non-strict schema validation (i.e. allow additional properties)")
-	cmd.Flags().BoolVarP(&flags.Quiet, "quiet", "", false, "Enable quiet mode (don't print skipped rule messages)")
+	cmd.Flags().BoolVarP(&flags.Quiet, "quiet", "", false, "Don't print skipped rules messages")
 }
 
 func GenerateTestCommandData(testCommandFlags *TestCommandFlags, localConfigContent *localConfig.LocalConfig, evaluationPrerunDataResp *cliClient.EvaluationPrerunDataResponse) (*TestCommandData, error) {

--- a/cmd/test/main_test.go
+++ b/cmd/test/main_test.go
@@ -144,7 +144,7 @@ type PrinterMock struct {
 	mock.Mock
 }
 
-func (p *PrinterMock) GetWarningsText(warnings []printer.Warning) string {
+func (p *PrinterMock) GetWarningsText(warnings []printer.Warning, quiet bool) string {
 	p.Called(warnings)
 	return ""
 }

--- a/pkg/evaluation/printer.go
+++ b/pkg/evaluation/printer.go
@@ -22,7 +22,7 @@ import (
 var out = color.Output
 
 type Printer interface {
-	GetWarningsText(warnings []printer.Warning) string
+	GetWarningsText(warnings []printer.Warning, quiet bool) string
 	GetSummaryTableText(summary printer.Summary) string
 	GetEvaluationSummaryText(summary printer.EvaluationSummary, k8sVersion string) string
 }
@@ -42,6 +42,7 @@ type PrintResultsData struct {
 	K8sValidationWarnings validation.K8sValidationWarningPerValidFile
 	CliVersion            string
 	IsCI                  bool
+	Quiet                 bool
 }
 
 type textOutputData struct {
@@ -55,6 +56,7 @@ type textOutputData struct {
 	Verbose               bool
 	policyName            string
 	k8sValidationWarnings validation.K8sValidationWarningPerValidFile
+	quiet                 bool
 }
 
 func SaveLastResultToJson(resultsData *PrintResultsData) {
@@ -152,6 +154,7 @@ func GetResultsText(resultsData *PrintResultsData) (string, error) {
 			policyName:            resultsData.PolicyName,
 			Verbose:               resultsData.Verbose,
 			k8sValidationWarnings: resultsData.K8sValidationWarnings,
+			quiet:                 resultsData.Quiet,
 		})
 	}
 }
@@ -261,7 +264,7 @@ func getTextOutput(outputData textOutputData) (string, error) {
 		return "", err
 	}
 
-	warningsText := outputData.printer.GetWarningsText(warnings)
+	warningsText := outputData.printer.GetWarningsText(warnings, outputData.quiet)
 	sb.WriteString(warningsText)
 
 	summary := parseEvaluationResultsToSummary(outputData.results, outputData.evaluationSummary, outputData.url, outputData.policyName)

--- a/pkg/evaluation/printer_test.go
+++ b/pkg/evaluation/printer_test.go
@@ -20,8 +20,8 @@ type mockPrinter struct {
 	mock.Mock
 }
 
-func (m *mockPrinter) GetWarningsText(warnings []printer.Warning) string {
-	m.Called(warnings)
+func (m *mockPrinter) GetWarningsText(warnings []printer.Warning, quiet bool) string {
+	m.Called(warnings, quiet)
 	return ""
 }
 
@@ -70,7 +70,7 @@ func TestPrintResults(t *testing.T) {
 	}
 	for _, tt := range tests {
 		mockedPrinter := &mockPrinter{}
-		mockedPrinter.On("GetWarningsText", mock.Anything, mock.Anything, mock.Anything)
+		mockedPrinter.On("GetWarningsText", mock.Anything, mock.Anything)
 		mockedPrinter.On("GetSummaryTableText", mock.Anything)
 		mockedPrinter.On("GetEvaluationSummaryText", mock.Anything, mock.Anything)
 
@@ -87,6 +87,7 @@ func TestPrintResults(t *testing.T) {
 				K8sVersion:            "1.18.0",
 				Verbose:               false,
 				PolicyName:            "Default",
+				Quiet:                 false,
 				K8sValidationWarnings: validation.K8sValidationWarningPerValidFile{},
 			})
 
@@ -101,7 +102,7 @@ func TestPrintResults(t *testing.T) {
 			} else {
 				pwd, _ := os.Getwd()
 				warnings, _ := parseToPrinterWarnings(tt.args.results.EvaluationResults, tt.args.invalidYamlFiles, tt.args.invalidK8sFiles, pwd, "1.18.0", validation.K8sValidationWarningPerValidFile{}, false)
-				mockedPrinter.AssertCalled(t, "GetWarningsText", warnings)
+				mockedPrinter.AssertCalled(t, "GetWarningsText", warnings, false)
 			}
 		})
 	}

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -142,7 +142,7 @@ func (p *Printer) getYamlSchemaResultsText(errorsResult []jsonschema.Detailed, e
 	return sb.String()
 }
 
-func (p *Printer) GetWarningsText(warnings []Warning) string {
+func (p *Printer) GetWarningsText(warnings []Warning, quiet bool) string {
 	var sb strings.Builder
 	for _, warning := range warnings {
 		sb.WriteString(p.GetTitleText(warning.Title))
@@ -164,27 +164,30 @@ func (p *Printer) GetWarningsText(warnings []Warning) string {
 			sb.WriteString(p.GetTextInColor("[X] Policy check\n", p.Theme.Colors.Highlight))
 			sb.WriteString("\n")
 
-			if len(warning.SkippedRules) > 0 {
-				sb.WriteString(fmt.Sprintf("%v", p.Theme.Colors.CyanBold.Sprintf("SKIPPED")+"\n\n"))
-			}
+			if !quiet {
 
-			for _, skippedRule := range warning.SkippedRules {
-				ruleName := p.Theme.Colors.CyanBold.Sprint(skippedRule.Name)
-
-				sb.WriteString(fmt.Sprintf("%v %v\n", p.Theme.Emoji.Skip, ruleName))
-
-				if skippedRule.DocumentationUrl != "" {
-					howToFix := p.Theme.Colors.Cyan.Sprint(skippedRule.DocumentationUrl)
-					sb.WriteString(fmt.Sprintf("    How to fix: %v\n", howToFix))
+				if len(warning.SkippedRules) > 0 {
+					sb.WriteString(fmt.Sprintf("%v", p.Theme.Colors.CyanBold.Sprintf("SKIPPED")+"\n\n"))
 				}
 
-				for _, occurrenceDetails := range skippedRule.OccurrencesDetails {
-					sb.WriteString(fmt.Sprintf("    - metadata.name: %v (kind: %v)\n", p.getStringOrNotAvailableText(occurrenceDetails.MetadataName), p.getStringOrNotAvailableText(occurrenceDetails.Kind)))
-					m := p.Theme.Colors.Highlight.Sprint(occurrenceDetails.SkipMessage)
-					sb.WriteString(fmt.Sprintf("%v %v\n", p.Theme.Emoji.Suggestion, m))
-				}
+				for _, skippedRule := range warning.SkippedRules {
+					ruleName := p.Theme.Colors.CyanBold.Sprint(skippedRule.Name)
 
-				sb.WriteString("\n")
+					sb.WriteString(fmt.Sprintf("%v %v\n", p.Theme.Emoji.Skip, ruleName))
+
+					if skippedRule.DocumentationUrl != "" {
+						howToFix := p.Theme.Colors.Cyan.Sprint(skippedRule.DocumentationUrl)
+						sb.WriteString(fmt.Sprintf("    How to fix: %v\n", howToFix))
+					}
+
+					for _, occurrenceDetails := range skippedRule.OccurrencesDetails {
+						sb.WriteString(fmt.Sprintf("    - metadata.name: %v (kind: %v)\n", p.getStringOrNotAvailableText(occurrenceDetails.MetadataName), p.getStringOrNotAvailableText(occurrenceDetails.Kind)))
+						m := p.Theme.Colors.Highlight.Sprint(occurrenceDetails.SkipMessage)
+						sb.WriteString(fmt.Sprintf("%v %v\n", p.Theme.Emoji.Suggestion, m))
+					}
+
+					sb.WriteString("\n")
+				}
 			}
 
 			for _, failedRule := range warning.FailedRules {

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -47,13 +47,36 @@ func TestGetWarningsText(t *testing.T) {
 			ExtraMessages: []ExtraMessage{{Text: "Are you trying to test a raw helm file? To run Datree with Helm - check out the helm plugin README:\nhttps://github.com/datreeio/helm-datree",
 				Color: "cyan"}},
 		},
+		{
+			Title: GetFileNameText("/datree/datree/internal/fixtures/kube/skipRule/k8s-demo-skip-two.yaml\n"),
+			SkippedRules: []FailedRule{
+				{
+					Name:        "Ensure workload has valid label values",
+					Occurrences: 1,
+					OccurrencesDetails: []OccurrenceDetails{{
+						MetadataName: "rss-site",
+						Kind:         "Deployment",
+						SkipMessage:  "skip first k8s-demo rule",
+					}},
+				},
+				{
+					Name:        "Ensure each container has a configured liveness probe",
+					Occurrences: 1,
+					OccurrencesDetails: []OccurrenceDetails{{
+						MetadataName: "rss-site",
+						Kind:         "Deployment",
+						SkipMessage:  "skip second k8s-demo rule",
+					}},
+				},
+			},
+		},
 	}
 
 	t.Run("Test GetWarningsText", func(t *testing.T) {
 
 		out = new(bytes.Buffer)
 
-		got := printer.GetWarningsText(warnings)
+		got := printer.GetWarningsText(warnings, false)
 
 		expected := []byte(
 			`>>  File: ~/.datree/k8-demo.yaml
@@ -100,6 +123,24 @@ Are you trying to test a raw helm file? To run Datree with Helm - check out the 
 https://github.com/datreeio/helm-datree
 [?] Policy check didn't run for this file
 
+>>  File: /datree/datree/internal/fixtures/kube/skipRule/k8s-demo-skip-two.yaml
+
+
+[V] YAML validation
+[V] Kubernetes schema validation
+
+[X] Policy check
+
+SKIPPED
+
+⏩  Ensure workload has valid label values
+    - metadata.name: rss-site (kind: Deployment)
+💡  skip first k8s-demo rule
+
+⏩  Ensure each container has a configured liveness probe
+    - metadata.name: rss-site (kind: Deployment)
+💡  skip second k8s-demo rule
+
 
 `)
 		assert.Equal(t, string(expected), got)
@@ -111,7 +152,7 @@ https://github.com/datreeio/helm-datree
 
 		printer.SetTheme(CreateSimpleTheme())
 
-		got := printer.GetWarningsText(warnings)
+		got := printer.GetWarningsText(warnings, true)
 
 		expected := []byte(
 			`>>  File: ~/.datree/k8-demo.yaml
@@ -157,6 +198,14 @@ https://github.com/datreeio/helm-datree
 Are you trying to test a raw helm file? To run Datree with Helm - check out the helm plugin README:
 https://github.com/datreeio/helm-datree
 [?] Policy check didn't run for this file
+
+>>  File: /datree/datree/internal/fixtures/kube/skipRule/k8s-demo-skip-two.yaml
+
+
+[V] YAML validation
+[V] Kubernetes schema validation
+
+[X] Policy check
 
 
 `)

--- a/scripts/deploy_release_candidate.sh
+++ b/scripts/deploy_release_candidate.sh
@@ -2,7 +2,7 @@
 set -ex
 
 MAJOR_VERSION=1
-MINOR_VERSION=7
+MINOR_VERSION=8
 
 git fetch --prune --unshallow --tags # needed for getting list of tags
 latestRcTag=$(git tag --sort=-version:refname | grep -E "^${MAJOR_VERSION}\.${MINOR_VERSION}.[0-9]+-rc" | head -n 1 | grep --only-matching "^${MAJOR_VERSION}\.${MINOR_VERSION}.[0-9]\+" || true)


### PR DESCRIPTION
This address #731

1. Adds a `quiet` flag to the CLI
2. Used to stop printing skipped rules
3. Summery will keep displaying the skip rule count
4. Only affects non-formatted output