### PR TITLE
fix: rule 32 logic

### DIFF
--- a/pkg/defaultRules/defaultRules.yaml
+++ b/pkg/defaultRules/defaultRules.yaml
@@ -945,8 +945,8 @@ rules:
           metadata:
             properties:
               annotations:
-                not:
-                  propertyNames:
+                propertyNames:
+                  not:
                     pattern: ^.*server-snippet$
   - id: 33
     name: "Prevent container security vulnerability (CVE-2021-25741)"

--- a/pkg/policy/tests/32-fail.yaml
+++ b/pkg/policy/tests/32-fail.yaml
@@ -4,6 +4,7 @@ metadata:
   name: simple-fanout-example
   annotations:
     nginx.ingress.kubernetes.io/server-snippet: dekljdkfj
+    aaa: bbb
 spec:
   rules:
   - host: foo.bar.com


### PR DESCRIPTION
rule 32 gave out false positives (rule should've failed, but it passed) whenever `annotations` had any other properties