### PR TITLE
feat: allow offline mode when connected to the internet

### DIFF
--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -157,6 +157,7 @@ type TestCommandData struct {
 	SaveRendered          bool
 	PermissiveSchema      bool
 	Quiet                 bool
+	IsOffline             bool
 }
 
 type TestCommandContext struct {
@@ -331,6 +332,7 @@ func GenerateTestCommandData(testCommandFlags *TestCommandFlags, localConfigCont
 		SaveRendered:          testCommandFlags.SaveRendered,
 		PermissiveSchema:      testCommandFlags.PermissiveSchema,
 		Quiet:                 testCommandFlags.Quiet,
+		IsOffline:             localConfigContent.Offline == "local",
 	}
 
 	return testCommandOptions, nil
@@ -463,6 +465,10 @@ func test(ctx *TestCommandContext, paths []string, testCommandData *TestCommandD
 				return err
 			}
 		}
+	}
+
+	if testCommandData.IsOffline {
+		ctx.Printer.PrintMessage("[INFO] You're running Datree in offline mode", "cyan")
 	}
 
 	if err != nil {

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -293,7 +293,7 @@ func GenerateTestCommandData(testCommandFlags *TestCommandFlags, localConfigCont
 	var err error
 
 	if testCommandFlags.PolicyConfig != "" {
-		if !evaluationPrerunDataResp.IsPolicyAsCodeMode {
+		if localConfigContent.Offline != "local" && !evaluationPrerunDataResp.IsPolicyAsCodeMode {
 			return nil, fmt.Errorf("to use --policy-config flag you must first enable policy-as-code mode: https://hub.datree.io/policy-as-code")
 		}
 

--- a/pkg/cliClient/evaluation.go
+++ b/pkg/cliClient/evaluation.go
@@ -94,7 +94,7 @@ type EvaluationPrerunDataResponse struct {
 
 func (c *CliClient) RequestEvaluationPrerunData(tokenId string, isCi bool) (*EvaluationPrerunDataResponse, error) {
 	if c.networkValidator.IsLocalMode() {
-		return &EvaluationPrerunDataResponse{IsPolicyAsCodeMode: true}, nil
+		return &EvaluationPrerunDataResponse{IsPolicyAsCodeMode: true, PoliciesJson: defaultPolicies.GetDefaultPoliciesStruct()}, nil
 	}
 
 	isCiQueryParam := "isCi=" + strconv.FormatBool(isCi)

--- a/pkg/networkValidator/networkValidator.go
+++ b/pkg/networkValidator/networkValidator.go
@@ -33,5 +33,5 @@ func (nv *NetworkValidator) IdentifyNetworkError(err error) error {
 }
 
 func (nv *NetworkValidator) IsLocalMode() bool {
-	return !nv.isBackendAvailable && nv.offlineMode == "local"
+	return nv.offlineMode == "local"
 }

--- a/pkg/networkValidator/validator_test.go
+++ b/pkg/networkValidator/validator_test.go
@@ -53,7 +53,7 @@ func TestNetworkValidatorOtherError(t *testing.T) {
 	err = test_identifyNetworkError_other_error(validator, "local")
 	isLocalMode = validator.IsLocalMode()
 	assert.Equal(t, nil, err)
-	assert.Equal(t, false, isLocalMode)
+	assert.Equal(t, true, isLocalMode)
 
 }
 


### PR DESCRIPTION
This pull request aims to address the use case where

> CI environments that may not be air gapped (ie. have internet access) but do not want the additional dependency on the external API introduced in their CI pipelines either for security, reproducibility or reliability reasons.

This use case was originally discussed in 
- https://github.com/datreeio/datree/issues/642
- https://github.com/datreeio/datree/issues/890

