### PR TITLE
feat: add datree-system pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,3 +6,12 @@
   pass_filenames: true
   args: [ 'test', '--only-k8s-files' ]
   entry: --user root datree/datree:latest
+
+- id: datree-system
+  name: datree test, run using datree installed
+  description: Prevent Kubernetes misconfigurations from reaching production
+  types: [ file, yaml ]
+  language: system
+  pass_filenames: true
+  args: [ 'test', '--only-k8s-files' ]
+  entry: datree


### PR DESCRIPTION
There are scenarios were one would like to use datree that is already installed in the system. Provide an alternate hook datree-system to use the datree binary install in the system.