### PR TITLE
ci: bump minor version to 9

### DIFF
--- a/scripts/deploy_release_candidate.sh
+++ b/scripts/deploy_release_candidate.sh
@@ -2,7 +2,7 @@
 set -ex
 
 MAJOR_VERSION=1
-MINOR_VERSION=8
+MINOR_VERSION=9
 
 git fetch --prune --unshallow --tags # needed for getting list of tags
 latestRcTag=$(git tag --sort=-version:refname | grep -E "^${MAJOR_VERSION}\.${MINOR_VERSION}.[0-9]+-rc" | head -n 1 | grep --only-matching "^${MAJOR_VERSION}\.${MINOR_VERSION}.[0-9]\+" || true)


### PR DESCRIPTION
due to the latest contribution: https://github.com/datreeio/datree/pull/932