### PR TITLE
perf: cache compiled rules to improve performance by 30%

### DIFF
--- a/pkg/jsonSchemaValidator/validator.go
+++ b/pkg/jsonSchemaValidator/validator.go
@@ -3,14 +3,15 @@ package jsonSchemaValidator
 import (
 	"encoding/json"
 	"fmt"
-	extensions "github.com/datreeio/datree/pkg/jsonSchemaValidator/extensions"
-	"github.com/ghodss/yaml"
-	"github.com/santhosh-tekuri/jsonschema/v5"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
+
+	extensions "github.com/datreeio/datree/pkg/jsonSchemaValidator/extensions"
+	"github.com/ghodss/yaml"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 type JSONSchemaValidator struct {

--- a/pkg/jsonSchemaValidator/validator.go
+++ b/pkg/jsonSchemaValidator/validator.go
@@ -53,7 +53,6 @@ func (jsv *JSONSchemaValidator) ValidateYamlSchema(schemaContent string, yamlCon
 
 func (jsv *JSONSchemaValidator) Validate(schemaContent string, yamlContent []byte) ([]jsonschema.Detailed, error) {
 	var jsonYamlContent interface{}
-
 	if err := json.Unmarshal(yamlContent, &jsonYamlContent); err != nil {
 		return nil, err
 	}

--- a/pkg/jsonSchemaValidator/validator.go
+++ b/pkg/jsonSchemaValidator/validator.go
@@ -3,16 +3,14 @@ package jsonSchemaValidator
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
-
 	extensions "github.com/datreeio/datree/pkg/jsonSchemaValidator/extensions"
 	"github.com/ghodss/yaml"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
 )
 
 type JSONSchemaValidator struct {
@@ -48,19 +46,9 @@ var resourceMaximum = jsonschema.MustCompileString("resourceMaximum.json", `{
 }`)
 
 func (jsv *JSONSchemaValidator) ValidateYamlSchema(schemaContent string, yamlContent string) ([]jsonschema.Detailed, error) {
-	startTime := time.Now()
 	jsonSchema, _ := yaml.YAMLToJSON([]byte(schemaContent))
 	jsonYamlContent, _ := yaml.YAMLToJSON([]byte(yamlContent))
-	yamlToJsonDuration := time.Since(startTime)
-
-	startTime = time.Now()
 	res, err := jsv.Validate(string(jsonSchema), jsonYamlContent)
-	jsonSchemaValidationDuration := time.Since(startTime)
-
-	jsonSchemaValidationPortion := float64(jsonSchemaValidationDuration) / float64(yamlToJsonDuration+jsonSchemaValidationDuration)
-
-	fmt.Println("jsonSchemaValidationPortion: ", jsonSchemaValidationPortion)
-
 	return res, err
 }
 

--- a/pkg/jsonSchemaValidator/validator.go
+++ b/pkg/jsonSchemaValidator/validator.go
@@ -73,6 +73,7 @@ func (jsv *JSONSchemaValidator) Validate(schemaContent string, yamlContent []byt
 	compiler.RegisterExtension("customKeyRule101", extensions.CustomKeyRule101, extensions.CustomKeyRule101Compiler{})
 	compiler.RegisterExtension("customKeyRegoRule", extensions.CustomKeyRegoRule, extensions.CustomKeyRegoDefinitionCompiler{})
 
+	// compiler.Compile() is an expensive operation. We cache the compiled schema in rulesSchemasCache to avoid re-compiling the same schema.
 	if _, ok := jsv.rulesSchemasCache.Load(schemaContent); !ok {
 		schema, err := compiler.Compile("schema.json")
 		if err != nil {

--- a/pkg/jsonSchemaValidator/validator.go
+++ b/pkg/jsonSchemaValidator/validator.go
@@ -52,7 +52,13 @@ func (jsv *JSONSchemaValidator) ValidateYamlSchema(schemaContent string, yamlCon
 	return res, err
 }
 
+var isPrinted = false
+
 func (jsv *JSONSchemaValidator) Validate(schemaContent string, yamlContent []byte) ([]jsonschema.Detailed, error) {
+	if isPrinted == false {
+		fmt.Println("@@@using the test version@@@")
+		isPrinted = true
+	}
 	var jsonYamlContent interface{}
 
 	if err := json.Unmarshal(yamlContent, &jsonYamlContent); err != nil {

--- a/pkg/jsonSchemaValidator/validator.go
+++ b/pkg/jsonSchemaValidator/validator.go
@@ -75,16 +75,14 @@ func (jsv *JSONSchemaValidator) Validate(schemaContent string, yamlContent []byt
 	compiler.RegisterExtension("customKeyRegoRule", extensions.CustomKeyRegoRule, extensions.CustomKeyRegoDefinitionCompiler{})
 
 	// compiler.Compile() is an expensive operation. We cache the compiled schema in rulesSchemasCache to avoid re-compiling the same schema.
-	if _, ok := jsv.rulesSchemasCache.Load(schemaContent); !ok {
-		schema, err := compiler.Compile("schema.json")
+	schemaAny, ok := jsv.rulesSchemasCache.Load(schemaContent)
+	if !ok {
+		compiledSchema, err := compiler.Compile("schema.json")
 		if err != nil {
 			return nil, err
 		}
-		jsv.rulesSchemasCache.Store(schemaContent, schema)
-	}
-	schemaAny, ok := jsv.rulesSchemasCache.Load(schemaContent)
-	if !ok {
-		return nil, fmt.Errorf("failed to load schema from rulesSchemasCache")
+		jsv.rulesSchemasCache.Store(schemaContent, compiledSchema)
+		schemaAny = compiledSchema
 	}
 	schema := schemaAny.(*jsonschema.Schema)
 

--- a/pkg/jsonSchemaValidator/validator.go
+++ b/pkg/jsonSchemaValidator/validator.go
@@ -84,7 +84,10 @@ func (jsv *JSONSchemaValidator) Validate(schemaContent string, yamlContent []byt
 		jsv.rulesSchemasCache.Store(schemaContent, compiledSchema)
 		schemaAny = compiledSchema
 	}
-	schema := schemaAny.(*jsonschema.Schema)
+	schema, ok := schemaAny.(*jsonschema.Schema)
+	if !ok {
+		return nil, fmt.Errorf("failed to convert schema to *jsonschema.Schema")
+	}
 
 	err := schema.Validate(jsonYamlContent)
 

--- a/pkg/jsonSchemaValidator/validator.go
+++ b/pkg/jsonSchemaValidator/validator.go
@@ -48,17 +48,10 @@ var resourceMaximum = jsonschema.MustCompileString("resourceMaximum.json", `{
 func (jsv *JSONSchemaValidator) ValidateYamlSchema(schemaContent string, yamlContent string) ([]jsonschema.Detailed, error) {
 	jsonSchema, _ := yaml.YAMLToJSON([]byte(schemaContent))
 	jsonYamlContent, _ := yaml.YAMLToJSON([]byte(yamlContent))
-	res, err := jsv.Validate(string(jsonSchema), jsonYamlContent)
-	return res, err
+	return jsv.Validate(string(jsonSchema), jsonYamlContent)
 }
 
-var isPrinted = false
-
 func (jsv *JSONSchemaValidator) Validate(schemaContent string, yamlContent []byte) ([]jsonschema.Detailed, error) {
-	if isPrinted == false {
-		fmt.Println("@@@using the test version@@@")
-		isPrinted = true
-	}
 	var jsonYamlContent interface{}
 
 	if err := json.Unmarshal(yamlContent, &jsonYamlContent); err != nil {


### PR DESCRIPTION
Note: this is a quick win. If we need to improve performance even further in the future, we should use proper performance profiling, and implement some bigger refactors :)

Scanner performance with ~200 resources and 62 rules enabled
Before:
![Screenshot 2023-06-07 at 10 44 19](https://github.com/datreeio/datree/assets/39004075/1af874c7-8ec8-49fd-a7f7-c0551cefbf6b)

After:
![Screenshot 2023-06-07 at 10 46 32](https://github.com/datreeio/datree/assets/39004075/53556e99-63d4-4c00-b3b1-4b18f5f4fa60)
