### PR TITLE
perf(httpClient): compare strings with `strings.EqualFold`

### DIFF
--- a/pkg/httpClient/client.go
+++ b/pkg/httpClient/client.go
@@ -162,7 +162,7 @@ func (c *Client) parseBody(body interface{}) (io.ReadWriter, error) {
 
 func (c *Client) getValueOfHeader(headers map[string]string, header string) string {
 	for currentHeader, currentValue := range headers {
-		if strings.ToLower(currentHeader) == strings.ToLower(header) {
+		if strings.EqualFold(currentHeader, header) {
 			return currentValue
 		}
 	}


### PR DESCRIPTION
Comparing two strings to the same case with `strings.ToLower` is more computational expensive than `strings.EqualFold`.

Sample benchmark:

```go
package httpClient_test

import (
	"strings"
	"testing"
)

func BenchmarkToLower(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if strings.ToLower("CONTENT-TYPE") != strings.ToLower("content-type") {
			b.Fail()
		}
	}
}

func BenchmarkEqualFold(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if !strings.EqualFold("CONTENT-TYPE", "content-type") {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/datreeio/datree/pkg/httpClient
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkToLower-16      	 8183317	       192.1 ns/op	      16 B/op	       1 allocs/op
BenchmarkEqualFold-16    	82634701	        12.92 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/datreeio/datree/pkg/httpClient	4.181s
```

Reference: https://staticcheck.dev/docs/checks/#SA6005