### PR TITLE
265-dheerajsingh0-docker-img-inject-the-account-token-from-the-pre-commit-config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,7 +5,7 @@
   language: docker_image
   pass_filenames: true
   args: [ 'test', '--only-k8s-files' ]
-  entry: --user root datree/datree:latest
+  entry: --user root --env DATREE_ACCOUNT_TOKEN datree/datree:latest
 
 - id: datree-system
   name: datree test, run using datree installed


### PR DESCRIPTION
#265 dheerajsingh0-inject-the-account-token-from-the-pre-commit-config-to-the-docker-img


Store your account token in an environment variable. 
This is generally safer than hardcoding it into scripts or configurations

`export DATREE_ACCOUNT_TOKEN='your_token_here'`
